### PR TITLE
🔀 :: (#235) 로그인 방식을 GAuth로 변경하고 토큰을 로컬에 저장

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,15 +23,16 @@
         <activity
             android:name=".presentation.view.splash.SplashActivity"
             android:exported="true">
+        </activity>
+        <activity
+            android:name=".presentation.view.intro.IntroActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-        <activity
-            android:name=".presentation.view.intro.IntroActivity"
-            android:exported="true"/>
         <activity
             android:name=".presentation.view.main.MainActivity"
             android:exported="false" />

--- a/app/src/main/java/com/msg/gcms/data/local/dao/TokenHandler.kt
+++ b/app/src/main/java/com/msg/gcms/data/local/dao/TokenHandler.kt
@@ -3,8 +3,8 @@ package com.msg.gcms.data.local.dao
 import android.content.Context
 import android.content.Context.MODE_PRIVATE
 
-class LoginToken(context: Context) {
-    private val name = "loginToken"
+class TokenHandler(context: Context) {
+    private val name = "TokenInfo"
 
     private val prefs = context.getSharedPreferences(name, MODE_PRIVATE)
 
@@ -18,5 +18,17 @@ class LoginToken(context: Context) {
         get() = prefs.getString("refreshToken", null)
         set(value) {
             prefs.edit().putString("refreshToken", value).apply()
+        }
+
+    var accessExp: String?
+        get() = prefs.getString("accessExp", null)
+        set(value) {
+            prefs.edit().putString("accessExp", value).apply()
+        }
+
+    var refreshExp: String?
+        get() = prefs.getString("refreshExp", null)
+        set(value) {
+            prefs.edit().putString("refreshExp", value).apply()
         }
 }

--- a/app/src/main/java/com/msg/gcms/data/remote/datasource/AuthDataSource.kt
+++ b/app/src/main/java/com/msg/gcms/data/remote/datasource/AuthDataSource.kt
@@ -1,10 +1,10 @@
-package com.msg.gcms.domain.datasource
+package com.msg.gcms.data.remote.datasource
 
 import com.msg.gcms.data.remote.dto.auth.request.CodeIssuanceRequest
 import com.msg.gcms.data.remote.dto.auth.request.SignInRequest
 import com.msg.gcms.data.remote.dto.auth.response.SignInResponse
 
-interface CommonDataSource {
+interface AuthDataSource {
     suspend fun postRegistration(body: SignInRequest): SignInResponse
 
     suspend fun postEmail(body: CodeIssuanceRequest)

--- a/app/src/main/java/com/msg/gcms/data/remote/datasource/AuthDataSourceImpl.kt
+++ b/app/src/main/java/com/msg/gcms/data/remote/datasource/AuthDataSourceImpl.kt
@@ -5,15 +5,13 @@ import com.msg.gcms.data.remote.dto.auth.request.SignInRequest
 import com.msg.gcms.data.remote.dto.auth.response.SignInResponse
 import com.msg.gcms.data.remote.network.AuthAPI
 import com.msg.gcms.data.remote.util.GCMSApiHandler
-import com.msg.gcms.domain.datasource.CommonDataSource
 import javax.inject.Inject
 
-class CommonDataSourceImpl @Inject constructor(
+class AuthDataSourceImpl @Inject constructor(
     private val service: AuthAPI
-) : CommonDataSource {
+) : AuthDataSource {
     override suspend fun postRegistration(body: SignInRequest): SignInResponse {
-        return GCMSApiHandler<SignInResponse>().
-        httpRequest {
+        return GCMSApiHandler<SignInResponse>().httpRequest {
             service.postSignIn(body)
         }.sendRequest()
     }

--- a/app/src/main/java/com/msg/gcms/data/remote/datasource/AuthDataSourceImpl.kt
+++ b/app/src/main/java/com/msg/gcms/data/remote/datasource/AuthDataSourceImpl.kt
@@ -11,9 +11,9 @@ class AuthDataSourceImpl @Inject constructor(
     private val service: AuthAPI
 ) : AuthDataSource {
     override suspend fun postRegistration(body: SignInRequest): SignInResponse {
-        return GCMSApiHandler<SignInResponse>().httpRequest {
-            service.postSignIn(body)
-        }.sendRequest()
+        return GCMSApiHandler<SignInResponse>()
+            .httpRequest { service.postSignIn(body) }
+            .sendRequest()
     }
 
     override suspend fun postEmail(body: CodeIssuanceRequest) {

--- a/app/src/main/java/com/msg/gcms/data/remote/datasource/ClubDataSource.kt
+++ b/app/src/main/java/com/msg/gcms/data/remote/datasource/ClubDataSource.kt
@@ -1,4 +1,4 @@
-package com.msg.gcms.domain.datasource
+package com.msg.gcms.data.remote.datasource
 
 import com.msg.gcms.data.remote.dto.club.request.ClubIdentificationRequest
 import com.msg.gcms.data.remote.dto.club.request.CreateClubRequest

--- a/app/src/main/java/com/msg/gcms/data/remote/datasource/ClubDataSourceImpl.kt
+++ b/app/src/main/java/com/msg/gcms/data/remote/datasource/ClubDataSourceImpl.kt
@@ -9,7 +9,6 @@ import com.msg.gcms.data.remote.dto.club.response.MemberInfo
 import com.msg.gcms.data.remote.dto.club.response.SummaryClubResponse
 import com.msg.gcms.data.remote.network.ClubAPI
 import com.msg.gcms.data.remote.util.GCMSApiHandler
-import com.msg.gcms.domain.datasource.ClubDataSource
 import javax.inject.Inject
 
 class ClubDataSourceImpl @Inject constructor(

--- a/app/src/main/java/com/msg/gcms/data/remote/datasource/CommonDataSourceImpl.kt
+++ b/app/src/main/java/com/msg/gcms/data/remote/datasource/CommonDataSourceImpl.kt
@@ -1,20 +1,20 @@
 package com.msg.gcms.data.remote.datasource
 
 import com.msg.gcms.data.remote.dto.auth.request.CodeIssuanceRequest
-import com.msg.gcms.data.remote.dto.auth.request.RegisterRequest
-import com.msg.gcms.data.remote.dto.auth.response.RegisterResponse
-import com.msg.gcms.data.remote.network.CommonAPI
+import com.msg.gcms.data.remote.dto.auth.request.SignInRequest
+import com.msg.gcms.data.remote.dto.auth.response.SignInResponse
+import com.msg.gcms.data.remote.network.AuthAPI
 import com.msg.gcms.data.remote.util.GCMSApiHandler
 import com.msg.gcms.domain.datasource.CommonDataSource
 import javax.inject.Inject
 
 class CommonDataSourceImpl @Inject constructor(
-    private val service: CommonAPI
+    private val service: AuthAPI
 ) : CommonDataSource {
-    override suspend fun postRegistration(body: RegisterRequest): RegisterResponse {
-        return GCMSApiHandler<RegisterResponse>().
+    override suspend fun postRegistration(body: SignInRequest): SignInResponse {
+        return GCMSApiHandler<SignInResponse>().
         httpRequest {
-            service.postRegistration(body)
+            service.postSignIn(body)
         }.sendRequest()
     }
 
@@ -36,8 +36,8 @@ class CommonDataSourceImpl @Inject constructor(
             .sendRequest()
     }
 
-    override suspend fun postRefresh(): RegisterResponse {
-        return GCMSApiHandler<RegisterResponse>()
+    override suspend fun postRefresh(): SignInResponse {
+        return GCMSApiHandler<SignInResponse>()
             .httpRequest { service.postRefresh() }
             .sendRequest()
     }

--- a/app/src/main/java/com/msg/gcms/data/remote/datasource/ImageDataSource.kt
+++ b/app/src/main/java/com/msg/gcms/data/remote/datasource/ImageDataSource.kt
@@ -1,4 +1,4 @@
-package com.msg.gcms.domain.datasource
+package com.msg.gcms.data.remote.datasource
 
 import okhttp3.MultipartBody
 

--- a/app/src/main/java/com/msg/gcms/data/remote/datasource/ImageDataSourceImpl.kt
+++ b/app/src/main/java/com/msg/gcms/data/remote/datasource/ImageDataSourceImpl.kt
@@ -2,7 +2,6 @@ package com.msg.gcms.data.remote.datasource
 
 import com.msg.gcms.data.remote.network.ImageAPI
 import com.msg.gcms.data.remote.util.GCMSApiHandler
-import com.msg.gcms.domain.datasource.ImageDataSource
 import okhttp3.MultipartBody
 import javax.inject.Inject
 

--- a/app/src/main/java/com/msg/gcms/data/remote/datasource/UserDataSource.kt
+++ b/app/src/main/java/com/msg/gcms/data/remote/datasource/UserDataSource.kt
@@ -1,4 +1,4 @@
-package com.msg.gcms.domain.datasource
+package com.msg.gcms.data.remote.datasource
 
 import com.msg.gcms.data.remote.dto.user.request.UserDeleteRequest
 import com.msg.gcms.data.remote.dto.user.request.UserProfileRequest

--- a/app/src/main/java/com/msg/gcms/data/remote/datasource/UserDataSourceImpl.kt
+++ b/app/src/main/java/com/msg/gcms/data/remote/datasource/UserDataSourceImpl.kt
@@ -6,7 +6,6 @@ import com.msg.gcms.data.remote.dto.user.response.UserData
 import com.msg.gcms.data.remote.dto.user.response.UserInfoResponse
 import com.msg.gcms.data.remote.network.UserAPI
 import com.msg.gcms.data.remote.util.GCMSApiHandler
-import com.msg.gcms.domain.datasource.UserDataSource
 import javax.inject.Inject
 
 class UserDataSourceImpl @Inject constructor(

--- a/app/src/main/java/com/msg/gcms/data/remote/dto/auth/request/SignInRequest.kt
+++ b/app/src/main/java/com/msg/gcms/data/remote/dto/auth/request/SignInRequest.kt
@@ -1,5 +1,5 @@
 package com.msg.gcms.data.remote.dto.auth.request
 
-data class RegisterRequest(
-    val idToken: String
+data class SignInRequest(
+    val code: String
 )

--- a/app/src/main/java/com/msg/gcms/data/remote/dto/auth/response/SignInResponse.kt
+++ b/app/src/main/java/com/msg/gcms/data/remote/dto/auth/response/SignInResponse.kt
@@ -1,7 +1,8 @@
 package com.msg.gcms.data.remote.dto.auth.response
 
-data class RegisterResponse(
+data class SignInResponse(
     val accessToken: String,
     val refreshToken: String,
-    val expiredAt: String
+    val accessExp: String,
+    val refreshExp: String
 )

--- a/app/src/main/java/com/msg/gcms/data/remote/network/AuthAPI.kt
+++ b/app/src/main/java/com/msg/gcms/data/remote/network/AuthAPI.kt
@@ -2,16 +2,16 @@ package com.msg.gcms.data.remote.network
 
 import com.msg.gcms.di.GCMSApplication
 import com.msg.gcms.data.remote.dto.auth.request.CodeIssuanceRequest
-import com.msg.gcms.data.remote.dto.auth.request.RegisterRequest
-import com.msg.gcms.data.remote.dto.auth.response.RegisterResponse
+import com.msg.gcms.data.remote.dto.auth.request.SignInRequest
+import com.msg.gcms.data.remote.dto.auth.response.SignInResponse
 import retrofit2.http.*
 
-interface CommonAPI {
+interface AuthAPI {
 
-    @POST("auth/mobile")
-    suspend fun postRegistration(
-        @Body body: RegisterRequest
-    ): RegisterResponse
+    @POST("auth/")
+    suspend fun postSignIn(
+        @Body body: SignInRequest
+    ): SignInResponse
 
     @POST("auth/verify")
     suspend fun postEmail(
@@ -30,5 +30,5 @@ interface CommonAPI {
     @POST("auth/refresh")
     suspend fun postRefresh(
         @Header("Authorization") refreshToken: String? = "Bearer ${GCMSApplication.prefs.refreshToken}"
-    ): RegisterResponse
+    ): SignInResponse
 }

--- a/app/src/main/java/com/msg/gcms/data/remote/network/AuthAPI.kt
+++ b/app/src/main/java/com/msg/gcms/data/remote/network/AuthAPI.kt
@@ -8,7 +8,7 @@ import retrofit2.http.*
 
 interface AuthAPI {
 
-    @POST("auth/")
+    @POST("auth")
     suspend fun postSignIn(
         @Body body: SignInRequest
     ): SignInResponse

--- a/app/src/main/java/com/msg/gcms/data/remote/network/LoginInterceptor.kt
+++ b/app/src/main/java/com/msg/gcms/data/remote/network/LoginInterceptor.kt
@@ -4,14 +4,29 @@ import com.msg.gcms.di.GCMSApplication
 import okhttp3.Interceptor
 import okhttp3.Response
 import java.io.IOException
-import kotlin.jvm.Throws
 
 class LoginInterceptor : Interceptor {
     @Throws(IOException::class)
     override fun intercept(chain: Interceptor.Chain): Response = with(chain) {
-        val req =
-            request().newBuilder().addHeader("Authorization", "Bearer ${GCMSApplication.prefs.accessToken}")
+        val request = chain.request()
+        val path = request.url.encodedPath
+        val method = request.method
+        val ignorePath = listOf(
+            "/auth/"
+        )
+        val ignoreMethod = listOf(
+            "POST"
+        )
+
+        if (ignorePath.contains(path) && ignoreMethod.contains(method)) {
+            return chain.proceed(request)
+        }
+
+        val accessTokenRequest =
+            request.newBuilder()
+                .addHeader("Authorization", "Bearer ${GCMSApplication.prefs.accessToken}")
                 .build()
-        return proceed(req)
+
+        return proceed(accessTokenRequest)
     }
 }

--- a/app/src/main/java/com/msg/gcms/data/remote/network/LoginInterceptor.kt
+++ b/app/src/main/java/com/msg/gcms/data/remote/network/LoginInterceptor.kt
@@ -12,7 +12,7 @@ class LoginInterceptor : Interceptor {
         val path = request.url.encodedPath
         val method = request.method
         val ignorePath = listOf(
-            "/auth/"
+            "/auth"
         )
         val ignoreMethod = listOf(
             "POST"

--- a/app/src/main/java/com/msg/gcms/data/remote/network/LoginInterceptor.kt
+++ b/app/src/main/java/com/msg/gcms/data/remote/network/LoginInterceptor.kt
@@ -11,14 +11,10 @@ class LoginInterceptor : Interceptor {
         val request = chain.request()
         val path = request.url.encodedPath
         val method = request.method
-        val ignorePath = listOf(
-            "/auth"
-        )
-        val ignoreMethod = listOf(
-            "POST"
-        )
+        val ignorePath = "/auth"
+        val ignoreMethod = "POST"
 
-        if (ignorePath.contains(path) && ignoreMethod.contains(method)) {
+        if (ignorePath == path && ignoreMethod == method) {
             return chain.proceed(request)
         }
 

--- a/app/src/main/java/com/msg/gcms/data/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/msg/gcms/data/repository/AuthRepositoryImpl.kt
@@ -3,12 +3,12 @@ package com.msg.gcms.data.repository
 import com.msg.gcms.data.remote.datasource.AuthDataSourceImpl
 import com.msg.gcms.data.remote.dto.auth.request.SignInRequest
 import com.msg.gcms.data.remote.dto.auth.response.SignInResponse
-import com.msg.gcms.domain.repository.CommonRepository
+import com.msg.gcms.domain.repository.AuthRepository
 import javax.inject.Inject
 
-class CommonRepositoryImpl @Inject constructor(
+class AuthRepositoryImpl @Inject constructor(
     private val datasource: AuthDataSourceImpl,
-) : CommonRepository {
+) : AuthRepository {
     override suspend fun postRegistration(body: SignInRequest): SignInResponse {
         return datasource.postRegistration(body = body)
     }

--- a/app/src/main/java/com/msg/gcms/data/repository/CommonRepositoryImpl.kt
+++ b/app/src/main/java/com/msg/gcms/data/repository/CommonRepositoryImpl.kt
@@ -1,15 +1,15 @@
 package com.msg.gcms.data.repository
 
 import com.msg.gcms.data.remote.datasource.CommonDataSourceImpl
-import com.msg.gcms.data.remote.dto.auth.request.RegisterRequest
-import com.msg.gcms.data.remote.dto.auth.response.RegisterResponse
+import com.msg.gcms.data.remote.dto.auth.request.SignInRequest
+import com.msg.gcms.data.remote.dto.auth.response.SignInResponse
 import com.msg.gcms.domain.repository.CommonRepository
 import javax.inject.Inject
 
 class CommonRepositoryImpl @Inject constructor(
     private val datasource: CommonDataSourceImpl,
 ) : CommonRepository {
-    override suspend fun postRegistration(body: RegisterRequest): RegisterResponse {
+    override suspend fun postRegistration(body: SignInRequest): SignInResponse {
         return datasource.postRegistration(body = body)
     }
 
@@ -17,7 +17,7 @@ class CommonRepositoryImpl @Inject constructor(
         return datasource.postLogout()
     }
 
-    override suspend fun postRefresh(): RegisterResponse {
+    override suspend fun postRefresh(): SignInResponse {
         return datasource.postRefresh()
     }
 }

--- a/app/src/main/java/com/msg/gcms/data/repository/CommonRepositoryImpl.kt
+++ b/app/src/main/java/com/msg/gcms/data/repository/CommonRepositoryImpl.kt
@@ -1,13 +1,13 @@
 package com.msg.gcms.data.repository
 
-import com.msg.gcms.data.remote.datasource.CommonDataSourceImpl
+import com.msg.gcms.data.remote.datasource.AuthDataSourceImpl
 import com.msg.gcms.data.remote.dto.auth.request.SignInRequest
 import com.msg.gcms.data.remote.dto.auth.response.SignInResponse
 import com.msg.gcms.domain.repository.CommonRepository
 import javax.inject.Inject
 
 class CommonRepositoryImpl @Inject constructor(
-    private val datasource: CommonDataSourceImpl,
+    private val datasource: AuthDataSourceImpl,
 ) : CommonRepository {
     override suspend fun postRegistration(body: SignInRequest): SignInResponse {
         return datasource.postRegistration(body = body)

--- a/app/src/main/java/com/msg/gcms/di/GCMSApplication.kt
+++ b/app/src/main/java/com/msg/gcms/di/GCMSApplication.kt
@@ -1,17 +1,17 @@
 package com.msg.gcms.di
 
 import android.app.Application
-import com.msg.gcms.data.local.dao.LoginToken
+import com.msg.gcms.data.local.dao.TokenHandler
 import dagger.hilt.android.HiltAndroidApp
 
 @HiltAndroidApp
 class GCMSApplication : Application() {
     companion object {
-        lateinit var prefs: LoginToken
+        lateinit var prefs: TokenHandler
     }
 
     override fun onCreate() {
         super.onCreate()
-        prefs = LoginToken(applicationContext)
+        prefs = TokenHandler(applicationContext)
     }
 }

--- a/app/src/main/java/com/msg/gcms/di/module/DataSourceModule.kt
+++ b/app/src/main/java/com/msg/gcms/di/module/DataSourceModule.kt
@@ -1,7 +1,7 @@
 package com.msg.gcms.di.module
 
 import com.msg.gcms.data.remote.datasource.ClubDataSourceImpl
-import com.msg.gcms.data.remote.datasource.CommonDataSourceImpl
+import com.msg.gcms.data.remote.datasource.AuthDataSourceImpl
 import com.msg.gcms.data.remote.datasource.ImageDataSourceImpl
 import com.msg.gcms.data.remote.network.ClubAPI
 import com.msg.gcms.data.remote.network.AuthAPI
@@ -19,8 +19,8 @@ import javax.inject.Singleton
 object DataSourceModule {
     @Provides
     @Singleton
-    fun provideCommonDataSource(service: AuthAPI) =
-        CommonDataSourceImpl(service)
+    fun provideAuthDataSource(service: AuthAPI) =
+        AuthDataSourceImpl(service)
 
     @Provides
     @Singleton

--- a/app/src/main/java/com/msg/gcms/di/module/DataSourceModule.kt
+++ b/app/src/main/java/com/msg/gcms/di/module/DataSourceModule.kt
@@ -4,7 +4,7 @@ import com.msg.gcms.data.remote.datasource.ClubDataSourceImpl
 import com.msg.gcms.data.remote.datasource.CommonDataSourceImpl
 import com.msg.gcms.data.remote.datasource.ImageDataSourceImpl
 import com.msg.gcms.data.remote.network.ClubAPI
-import com.msg.gcms.data.remote.network.CommonAPI
+import com.msg.gcms.data.remote.network.AuthAPI
 import com.msg.gcms.data.remote.network.ImageAPI
 import com.msg.gcms.data.remote.datasource.UserDataSourceImpl
 import com.msg.gcms.data.remote.network.UserAPI
@@ -19,7 +19,7 @@ import javax.inject.Singleton
 object DataSourceModule {
     @Provides
     @Singleton
-    fun provideCommonDataSource(service: CommonAPI) =
+    fun provideCommonDataSource(service: AuthAPI) =
         CommonDataSourceImpl(service)
 
     @Provides

--- a/app/src/main/java/com/msg/gcms/di/module/NetworkModule.kt
+++ b/app/src/main/java/com/msg/gcms/di/module/NetworkModule.kt
@@ -2,7 +2,7 @@ package com.msg.gcms.di.module
 
 import com.msg.gcms.BuildConfig
 import com.msg.gcms.data.remote.network.ClubAPI
-import com.msg.gcms.data.remote.network.CommonAPI
+import com.msg.gcms.data.remote.network.AuthAPI
 import com.msg.gcms.data.remote.network.ImageAPI
 import com.msg.gcms.data.remote.network.LoginInterceptor
 import com.msg.gcms.data.remote.network.UserAPI
@@ -56,8 +56,8 @@ object NetworkModule {
 
     @Provides
     @Singleton
-    fun provideCommonService(retrofit: Retrofit): CommonAPI {
-        return retrofit.create(CommonAPI::class.java)
+    fun provideAuthService(retrofit: Retrofit): AuthAPI {
+        return retrofit.create(AuthAPI::class.java)
     }
 
     @Provides

--- a/app/src/main/java/com/msg/gcms/di/module/RepositoryModule.kt
+++ b/app/src/main/java/com/msg/gcms/di/module/RepositoryModule.kt
@@ -5,11 +5,11 @@ import com.msg.gcms.data.remote.datasource.AuthDataSourceImpl
 import com.msg.gcms.data.remote.datasource.ImageDataSourceImpl
 import com.msg.gcms.data.remote.datasource.UserDataSourceImpl
 import com.msg.gcms.data.repository.ClubRepositoryImpl
-import com.msg.gcms.data.repository.CommonRepositoryImpl
+import com.msg.gcms.data.repository.AuthRepositoryImpl
 import com.msg.gcms.data.repository.ImageRepositoryImpl
 import com.msg.gcms.data.repository.UserRepositoryImpl
 import com.msg.gcms.domain.repository.ClubRepository
-import com.msg.gcms.domain.repository.CommonRepository
+import com.msg.gcms.domain.repository.AuthRepository
 import com.msg.gcms.domain.repository.ImageRepository
 import com.msg.gcms.domain.repository.UserRepository
 import dagger.Module
@@ -23,8 +23,8 @@ import javax.inject.Singleton
 object RepositoryModule {
     @Provides
     @Singleton
-    fun provideCommonRepository(dataSource: AuthDataSourceImpl): CommonRepository =
-        CommonRepositoryImpl(dataSource)
+    fun provideAuthRepository(dataSource: AuthDataSourceImpl): AuthRepository =
+        AuthRepositoryImpl(dataSource)
 
     @Provides
     @Singleton

--- a/app/src/main/java/com/msg/gcms/di/module/RepositoryModule.kt
+++ b/app/src/main/java/com/msg/gcms/di/module/RepositoryModule.kt
@@ -1,7 +1,7 @@
 package com.msg.gcms.di.module
 
 import com.msg.gcms.data.remote.datasource.ClubDataSourceImpl
-import com.msg.gcms.data.remote.datasource.CommonDataSourceImpl
+import com.msg.gcms.data.remote.datasource.AuthDataSourceImpl
 import com.msg.gcms.data.remote.datasource.ImageDataSourceImpl
 import com.msg.gcms.data.remote.datasource.UserDataSourceImpl
 import com.msg.gcms.data.repository.ClubRepositoryImpl
@@ -23,7 +23,7 @@ import javax.inject.Singleton
 object RepositoryModule {
     @Provides
     @Singleton
-    fun provideCommonRepository(dataSource: CommonDataSourceImpl): CommonRepository =
+    fun provideCommonRepository(dataSource: AuthDataSourceImpl): CommonRepository =
         CommonRepositoryImpl(dataSource)
 
     @Provides

--- a/app/src/main/java/com/msg/gcms/di/module/UseCaseModule.kt
+++ b/app/src/main/java/com/msg/gcms/di/module/UseCaseModule.kt
@@ -1,7 +1,7 @@
 package com.msg.gcms.di.module
 
 import com.msg.gcms.domain.repository.ClubRepository
-import com.msg.gcms.domain.repository.CommonRepository
+import com.msg.gcms.domain.repository.AuthRepository
 import com.msg.gcms.domain.repository.ImageRepository
 import com.msg.gcms.domain.repository.UserRepository
 import com.msg.gcms.domain.usecase.club.ApplicantAcceptUseCase
@@ -19,9 +19,9 @@ import com.msg.gcms.domain.usecase.club.PostCreateClubUseCase
 import com.msg.gcms.domain.usecase.club.PutClubCloseUseCase
 import com.msg.gcms.domain.usecase.club.PutClubOpenUseCase
 import com.msg.gcms.domain.usecase.club.UserKickUseCase
-import com.msg.gcms.domain.usecase.common.LogoutUseCase
-import com.msg.gcms.domain.usecase.common.RefreshUseCase
-import com.msg.gcms.domain.usecase.common.RegistrationUseCase
+import com.msg.gcms.domain.usecase.auth.LogoutUseCase
+import com.msg.gcms.domain.usecase.auth.RefreshUseCase
+import com.msg.gcms.domain.usecase.auth.SignInUseCase
 import com.msg.gcms.domain.usecase.image.ImageUseCase
 import com.msg.gcms.domain.usecase.user.DeleteUserUseCase
 import com.msg.gcms.domain.usecase.user.EditProfileUseCase
@@ -115,22 +115,22 @@ object UseCaseModule {
         UserKickUseCase(repository)
 
 
-    // --- Common UseCase ---
+    // --- Auth UseCase ---
 
     @Provides
     @Singleton
-    fun provideLogoutUseCase(repository: CommonRepository): LogoutUseCase =
+    fun provideLogoutUseCase(repository: AuthRepository): LogoutUseCase =
         LogoutUseCase(repository)
 
     @Provides
     @Singleton
-    fun provideRefreshUseCase(repository: CommonRepository): RefreshUseCase =
+    fun provideRefreshUseCase(repository: AuthRepository): RefreshUseCase =
         RefreshUseCase(repository)
 
     @Provides
     @Singleton
-    fun provideRegistrationUseCase(repository: CommonRepository): RegistrationUseCase =
-        RegistrationUseCase(repository)
+    fun provideSignInUseCase(repository: AuthRepository): SignInUseCase =
+        SignInUseCase(repository)
 
 
     // --- Image UseCase ---

--- a/app/src/main/java/com/msg/gcms/domain/datasource/CommonDataSource.kt
+++ b/app/src/main/java/com/msg/gcms/domain/datasource/CommonDataSource.kt
@@ -1,11 +1,11 @@
 package com.msg.gcms.domain.datasource
 
 import com.msg.gcms.data.remote.dto.auth.request.CodeIssuanceRequest
-import com.msg.gcms.data.remote.dto.auth.request.RegisterRequest
-import com.msg.gcms.data.remote.dto.auth.response.RegisterResponse
+import com.msg.gcms.data.remote.dto.auth.request.SignInRequest
+import com.msg.gcms.data.remote.dto.auth.response.SignInResponse
 
 interface CommonDataSource {
-    suspend fun postRegistration(body: RegisterRequest): RegisterResponse
+    suspend fun postRegistration(body: SignInRequest): SignInResponse
 
     suspend fun postEmail(body: CodeIssuanceRequest)
 
@@ -13,5 +13,5 @@ interface CommonDataSource {
 
     suspend fun postLogout()
 
-    suspend fun postRefresh(): RegisterResponse
+    suspend fun postRefresh(): SignInResponse
 }

--- a/app/src/main/java/com/msg/gcms/domain/repository/AuthRepository.kt
+++ b/app/src/main/java/com/msg/gcms/domain/repository/AuthRepository.kt
@@ -3,7 +3,7 @@ package com.msg.gcms.domain.repository
 import com.msg.gcms.data.remote.dto.auth.request.SignInRequest
 import com.msg.gcms.data.remote.dto.auth.response.SignInResponse
 
-interface CommonRepository {
+interface AuthRepository {
     suspend fun postRegistration(
         body: SignInRequest
     ): SignInResponse

--- a/app/src/main/java/com/msg/gcms/domain/repository/CommonRepository.kt
+++ b/app/src/main/java/com/msg/gcms/domain/repository/CommonRepository.kt
@@ -1,14 +1,14 @@
 package com.msg.gcms.domain.repository
 
-import com.msg.gcms.data.remote.dto.auth.request.RegisterRequest
-import com.msg.gcms.data.remote.dto.auth.response.RegisterResponse
+import com.msg.gcms.data.remote.dto.auth.request.SignInRequest
+import com.msg.gcms.data.remote.dto.auth.response.SignInResponse
 
 interface CommonRepository {
     suspend fun postRegistration(
-        body: RegisterRequest
-    ): RegisterResponse
+        body: SignInRequest
+    ): SignInResponse
 
     suspend fun postLogout()
 
-    suspend fun postRefresh(): RegisterResponse
+    suspend fun postRefresh(): SignInResponse
 }

--- a/app/src/main/java/com/msg/gcms/domain/usecase/auth/LogoutUseCase.kt
+++ b/app/src/main/java/com/msg/gcms/domain/usecase/auth/LogoutUseCase.kt
@@ -1,10 +1,10 @@
-package com.msg.gcms.domain.usecase.common
+package com.msg.gcms.domain.usecase.auth
 
-import com.msg.gcms.domain.repository.CommonRepository
+import com.msg.gcms.domain.repository.AuthRepository
 import javax.inject.Inject
 
 class LogoutUseCase @Inject constructor(
-    private val commonRepository: CommonRepository
+    private val commonRepository: AuthRepository
 ){
     suspend operator fun invoke() = kotlin.runCatching {
         commonRepository.postLogout()

--- a/app/src/main/java/com/msg/gcms/domain/usecase/auth/RefreshUseCase.kt
+++ b/app/src/main/java/com/msg/gcms/domain/usecase/auth/RefreshUseCase.kt
@@ -1,10 +1,10 @@
-package com.msg.gcms.domain.usecase.common
+package com.msg.gcms.domain.usecase.auth
 
-import com.msg.gcms.domain.repository.CommonRepository
+import com.msg.gcms.domain.repository.AuthRepository
 import javax.inject.Inject
 
 class RefreshUseCase @Inject constructor(
-    private val repository: CommonRepository
+    private val repository: AuthRepository
 ) {
     suspend operator fun invoke() = kotlin.runCatching {
         repository.postRefresh()

--- a/app/src/main/java/com/msg/gcms/domain/usecase/auth/SignInUseCase.kt
+++ b/app/src/main/java/com/msg/gcms/domain/usecase/auth/SignInUseCase.kt
@@ -1,11 +1,11 @@
-package com.msg.gcms.domain.usecase.common
+package com.msg.gcms.domain.usecase.auth
 
 import com.msg.gcms.data.remote.dto.auth.request.SignInRequest
-import com.msg.gcms.domain.repository.CommonRepository
+import com.msg.gcms.domain.repository.AuthRepository
 import javax.inject.Inject
 
-class RegistrationUseCase @Inject constructor(
-    private val repository: CommonRepository
+class SignInUseCase @Inject constructor(
+    private val repository: AuthRepository
 ) {
     suspend operator fun invoke(body: SignInRequest) = kotlin.runCatching {
         repository.postRegistration(body)

--- a/app/src/main/java/com/msg/gcms/domain/usecase/common/RegistrationUseCase.kt
+++ b/app/src/main/java/com/msg/gcms/domain/usecase/common/RegistrationUseCase.kt
@@ -1,13 +1,13 @@
 package com.msg.gcms.domain.usecase.common
 
-import com.msg.gcms.data.remote.dto.auth.request.RegisterRequest
+import com.msg.gcms.data.remote.dto.auth.request.SignInRequest
 import com.msg.gcms.domain.repository.CommonRepository
 import javax.inject.Inject
 
 class RegistrationUseCase @Inject constructor(
     private val repository: CommonRepository
 ) {
-    suspend operator fun invoke(body: RegisterRequest) = kotlin.runCatching {
+    suspend operator fun invoke(body: SignInRequest) = kotlin.runCatching {
         repository.postRegistration(body)
     }
 }

--- a/app/src/main/java/com/msg/gcms/presentation/view/club/detail/DetailFragment.kt
+++ b/app/src/main/java/com/msg/gcms/presentation/view/club/detail/DetailFragment.kt
@@ -191,12 +191,9 @@ class DetailFragment : BaseFragment<FragmentDetailBinding>(R.layout.fragment_det
     }
 
     private fun clickSubmitBtn() {
-        // Todo(KimHs) 여기는 뭘처리하길래 result를 넘기고 안씀? - LeeHyeonbin
-        detailViewModel.result.value!!.club.let { result ->
-            binding.submitBtn.setOnClickListener {
-                observeStatus()
-                changeDialog()
-            }
+        binding.submitBtn.setOnClickListener {
+            observeStatus()
+            changeDialog()
         }
     }
 

--- a/app/src/main/java/com/msg/gcms/presentation/view/intro/IntroActivity.kt
+++ b/app/src/main/java/com/msg/gcms/presentation/view/intro/IntroActivity.kt
@@ -2,6 +2,7 @@ package com.msg.gcms.presentation.view.intro
 
 import android.content.Intent
 import android.net.Uri
+import android.util.Log
 import android.view.View
 import androidx.activity.viewModels
 import com.msg.gauthsignin.GAuthButton
@@ -12,6 +13,7 @@ import com.msg.gcms.R
 import com.msg.gcms.databinding.ActivityIntroBinding
 import com.msg.gcms.presentation.base.BaseActivity
 import com.msg.gcms.presentation.viewmodel.AuthViewModel
+import com.msg.gcms.presentation.viewmodel.util.Event
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -24,6 +26,7 @@ class IntroActivity : BaseActivity<ActivityIntroBinding>(R.layout.activity_intro
     }
 
     override fun observeEvent() {
+        observeSignInEvent()
     }
 
     private fun setGAuthButtonComponent() {
@@ -44,7 +47,25 @@ class IntroActivity : BaseActivity<ActivityIntroBinding>(R.layout.activity_intro
                 clientId = BuildConfig.CLIENT_ID,
                 redirectUri = BuildConfig.REDIRECT_URI,
             ) {
+                Log.d("TAG",it)
+                viewModel.postSignInRequest(code = it)
+            }
+        }
+    }
 
+    private fun observeSignInEvent() {
+        viewModel.postSignInRequest.observe(this) { event ->
+            when (event) {
+                Event.BadRequest -> Log.d("TAG",event.toString())
+                Event.Conflict -> Log.d("TAG",event.toString())
+                Event.ForBidden -> Log.d("TAG",event.toString())
+                Event.NotAcceptable -> Log.d("TAG",event.toString())
+                Event.NotFound -> Log.d("TAG",event.toString())
+                Event.Server -> Log.d("TAG",event.toString())
+                Event.Success -> Log.d("TAG",event.toString())
+                Event.TimeOut -> Log.d("TAG",event.toString())
+                Event.UnKnown -> Log.d("TAG",event.toString())
+                Event.Unauthorized -> Log.d("TAG",event.toString())
             }
         }
     }

--- a/app/src/main/java/com/msg/gcms/presentation/view/intro/IntroActivity.kt
+++ b/app/src/main/java/com/msg/gcms/presentation/view/intro/IntroActivity.kt
@@ -2,8 +2,8 @@ package com.msg.gcms.presentation.view.intro
 
 import android.content.Intent
 import android.net.Uri
-import android.util.Log
 import android.view.View
+import android.widget.Toast
 import androidx.activity.viewModels
 import com.msg.gauthsignin.GAuthButton
 import com.msg.gauthsignin.GAuthSigninWebView
@@ -14,14 +14,17 @@ import com.msg.gcms.databinding.ActivityIntroBinding
 import com.msg.gcms.presentation.base.BaseActivity
 import com.msg.gcms.presentation.viewmodel.AuthViewModel
 import com.msg.gcms.presentation.viewmodel.util.Event
+import com.msg.gcms.ui.component.intro.component.ProgressDialog
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class IntroActivity : BaseActivity<ActivityIntroBinding>(R.layout.activity_intro) {
 
+    private lateinit var progressDialog: ProgressDialog
     private val viewModel by viewModels<AuthViewModel>()
 
     override fun viewSetting() {
+        progressDialog = ProgressDialog(this)
         setGAuthButtonComponent()
     }
 
@@ -36,6 +39,7 @@ class IntroActivity : BaseActivity<ActivityIntroBinding>(R.layout.activity_intro
                 actionType = Types.ActionType.SIGNIN,
                 colors = Types.Colors.OUTLINE
             ) {
+                binding.gAuthWebView.visibility = View.VISIBLE
                 setGAuthWebViewComponent()
             }
         }
@@ -47,7 +51,8 @@ class IntroActivity : BaseActivity<ActivityIntroBinding>(R.layout.activity_intro
                 clientId = BuildConfig.CLIENT_ID,
                 redirectUri = BuildConfig.REDIRECT_URI,
             ) {
-                Log.d("TAG",it)
+                progressDialog.show()
+                binding.gAuthWebView.visibility = View.INVISIBLE
                 viewModel.postSignInRequest(code = it)
             }
         }
@@ -55,17 +60,14 @@ class IntroActivity : BaseActivity<ActivityIntroBinding>(R.layout.activity_intro
 
     private fun observeSignInEvent() {
         viewModel.postSignInRequest.observe(this) { event ->
+            progressDialog.dismiss()
             when (event) {
-                Event.BadRequest -> Log.d("TAG",event.toString())
-                Event.Conflict -> Log.d("TAG",event.toString())
-                Event.ForBidden -> Log.d("TAG",event.toString())
-                Event.NotAcceptable -> Log.d("TAG",event.toString())
-                Event.NotFound -> Log.d("TAG",event.toString())
-                Event.Server -> Log.d("TAG",event.toString())
-                Event.Success -> Log.d("TAG",event.toString())
-                Event.TimeOut -> Log.d("TAG",event.toString())
-                Event.UnKnown -> Log.d("TAG",event.toString())
-                Event.Unauthorized -> Log.d("TAG",event.toString())
+                Event.Success -> {
+                    Toast.makeText(this, "로그인에 성공했습니다!", Toast.LENGTH_SHORT).show()
+                }
+                else -> {
+                    Toast.makeText(this, "알 수 없는 오류가 발생했습니다.", Toast.LENGTH_SHORT).show()
+                }
             }
         }
     }

--- a/app/src/main/java/com/msg/gcms/presentation/view/intro/IntroActivity.kt
+++ b/app/src/main/java/com/msg/gcms/presentation/view/intro/IntroActivity.kt
@@ -11,13 +11,13 @@ import com.msg.gcms.BuildConfig
 import com.msg.gcms.R
 import com.msg.gcms.databinding.ActivityIntroBinding
 import com.msg.gcms.presentation.base.BaseActivity
-import com.msg.gcms.presentation.viewmodel.RegistrationViewModel
+import com.msg.gcms.presentation.viewmodel.AuthViewModel
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class IntroActivity : BaseActivity<ActivityIntroBinding>(R.layout.activity_intro) {
 
-    private val viewModel by viewModels<RegistrationViewModel>()
+    private val viewModel by viewModels<AuthViewModel>()
 
     override fun viewSetting() {
         setGAuthButtonComponent()

--- a/app/src/main/java/com/msg/gcms/presentation/view/intro/IntroActivity.kt
+++ b/app/src/main/java/com/msg/gcms/presentation/view/intro/IntroActivity.kt
@@ -12,6 +12,7 @@ import com.msg.gcms.BuildConfig
 import com.msg.gcms.R
 import com.msg.gcms.databinding.ActivityIntroBinding
 import com.msg.gcms.presentation.base.BaseActivity
+import com.msg.gcms.presentation.view.main.MainActivity
 import com.msg.gcms.presentation.viewmodel.AuthViewModel
 import com.msg.gcms.presentation.viewmodel.util.Event
 import com.msg.gcms.ui.component.intro.component.ProgressDialog
@@ -63,11 +64,10 @@ class IntroActivity : BaseActivity<ActivityIntroBinding>(R.layout.activity_intro
             progressDialog.dismiss()
             when (event) {
                 Event.Success -> {
-                    Toast.makeText(this, "로그인에 성공했습니다!", Toast.LENGTH_SHORT).show()
+                    startActivity(Intent(this, MainActivity::class.java))
+                    finish()
                 }
-                else -> {
-                    Toast.makeText(this, "알 수 없는 오류가 발생했습니다.", Toast.LENGTH_SHORT).show()
-                }
+                else -> Toast.makeText(this, "알 수 없는 오류가 발생했습니다.", Toast.LENGTH_SHORT).show()
             }
         }
     }

--- a/app/src/main/java/com/msg/gcms/presentation/view/splash/SplashActivity.kt
+++ b/app/src/main/java/com/msg/gcms/presentation/view/splash/SplashActivity.kt
@@ -7,14 +7,14 @@ import androidx.appcompat.app.AppCompatActivity
 import com.msg.gcms.R
 
 import com.msg.gcms.presentation.view.main.MainActivity
-import com.msg.gcms.presentation.viewmodel.RegistrationViewModel
+import com.msg.gcms.presentation.viewmodel.AuthViewModel
 import com.msg.gcms.presentation.view.intro.IntroActivity
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class SplashActivity : AppCompatActivity() {
 
-    private val viewModel by viewModels<RegistrationViewModel>()
+    private val viewModel by viewModels<AuthViewModel>()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/com/msg/gcms/presentation/viewmodel/AuthViewModel.kt
+++ b/app/src/main/java/com/msg/gcms/presentation/viewmodel/AuthViewModel.kt
@@ -65,6 +65,8 @@ class AuthViewModel @Inject constructor(
         GCMSApplication.prefs.apply {
             accessToken = response.accessToken
             refreshToken = response.refreshToken
+            accessExp = response.accessExp
+            refreshExp = response.refreshExp
         }
     }
 }

--- a/app/src/main/java/com/msg/gcms/presentation/viewmodel/AuthViewModel.kt
+++ b/app/src/main/java/com/msg/gcms/presentation/viewmodel/AuthViewModel.kt
@@ -5,14 +5,14 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import com.msg.gcms.di.GCMSApplication
 import com.msg.gcms.data.remote.dto.auth.response.SignInResponse
-import com.msg.gcms.domain.usecase.common.RefreshUseCase
-import com.msg.gcms.domain.usecase.common.RegistrationUseCase
+import com.msg.gcms.domain.usecase.auth.RefreshUseCase
+import com.msg.gcms.domain.usecase.auth.SignInUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 
 @HiltViewModel
-class RegistrationViewModel @Inject constructor(
-    private val registrationUseCase: RegistrationUseCase,
+class AuthViewModel @Inject constructor(
+    private val registrationUseCase: SignInUseCase,
     private val refreshUseCase: RefreshUseCase
 ) : ViewModel() {
 

--- a/app/src/main/java/com/msg/gcms/presentation/viewmodel/AuthViewModel.kt
+++ b/app/src/main/java/com/msg/gcms/presentation/viewmodel/AuthViewModel.kt
@@ -1,6 +1,5 @@
 package com.msg.gcms.presentation.viewmodel
 
-import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -23,9 +22,6 @@ class AuthViewModel @Inject constructor(
     private val signInUseCase: SignInUseCase,
     private val refreshUseCase: RefreshUseCase
 ) : ViewModel() {
-
-    private val TAG = "AuthViewModel"
-
     private val _postSignInRequest = MutableLiveData<Event>()
     val postSignInRequest: LiveData<Event> get() = _postSignInRequest
 
@@ -36,27 +32,14 @@ class AuthViewModel @Inject constructor(
         signInUseCase(
             SignInRequest(code = code)
         ).onSuccess {
-            Log.d(TAG, it.toString())
             saveToken(it)
             _postSignInRequest.value = Event.Success
         }.onFailure {
             _postSignInRequest.value = when (it) {
-                is BadRequestException -> {
-                    Log.d(TAG, "PostSignIn: $it.")
-                    Event.BadRequest
-                }
-                is UnauthorizedException -> {
-                    Log.d(TAG, "PostSignIn: $it")
-                    Event.Unauthorized
-                }
-                is NotFoundException -> {
-                    Log.d(TAG, "PostSignIn: $it")
-                    Event.NotFound
-                }
-                else -> {
-                    Log.d(TAG, "PostSignIn: $it")
-                    Event.UnKnown
-                }
+                is BadRequestException -> Event.BadRequest
+                is UnauthorizedException -> Event.Unauthorized
+                is NotFoundException -> Event.NotFound
+                else -> Event.UnKnown
             }
         }
     }

--- a/app/src/main/java/com/msg/gcms/presentation/viewmodel/AuthViewModel.kt
+++ b/app/src/main/java/com/msg/gcms/presentation/viewmodel/AuthViewModel.kt
@@ -42,19 +42,19 @@ class AuthViewModel @Inject constructor(
         }.onFailure {
             _postSignInRequest.value = when (it) {
                 is BadRequestException -> {
-                    Log.d(TAG, "getDetail: $it.")
+                    Log.d(TAG, "PostSignIn: $it.")
                     Event.BadRequest
                 }
                 is UnauthorizedException -> {
-                    Log.d(TAG, "getDetail: $it")
+                    Log.d(TAG, "PostSignIn: $it")
                     Event.Unauthorized
                 }
                 is NotFoundException -> {
-                    Log.d(TAG, "getDetail: $it")
+                    Log.d(TAG, "PostSignIn: $it")
                     Event.NotFound
                 }
                 else -> {
-                    Log.d(TAG, "getDetail: $it")
+                    Log.d(TAG, "PostSignIn: $it")
                     Event.UnKnown
                 }
             }

--- a/app/src/main/java/com/msg/gcms/presentation/viewmodel/ProfileViewModel.kt
+++ b/app/src/main/java/com/msg/gcms/presentation/viewmodel/ProfileViewModel.kt
@@ -10,7 +10,7 @@ import com.msg.gcms.data.remote.dto.user.response.UserInfoResponse
 import com.msg.gcms.domain.exception.BadRequestException
 import com.msg.gcms.domain.exception.NotFoundException
 import com.msg.gcms.domain.exception.UnauthorizedException
-import com.msg.gcms.domain.usecase.common.LogoutUseCase
+import com.msg.gcms.domain.usecase.auth.LogoutUseCase
 import com.msg.gcms.domain.usecase.image.ImageUseCase
 import com.msg.gcms.domain.usecase.user.EditProfileUseCase
 import com.msg.gcms.domain.usecase.user.GetUserInfoUseCase

--- a/app/src/main/java/com/msg/gcms/presentation/viewmodel/RegistrationViewModel.kt
+++ b/app/src/main/java/com/msg/gcms/presentation/viewmodel/RegistrationViewModel.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import com.msg.gcms.di.GCMSApplication
-import com.msg.gcms.data.remote.dto.auth.response.RegisterResponse
+import com.msg.gcms.data.remote.dto.auth.response.SignInResponse
 import com.msg.gcms.domain.usecase.common.RefreshUseCase
 import com.msg.gcms.domain.usecase.common.RegistrationUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -24,7 +24,7 @@ class RegistrationViewModel @Inject constructor(
 
     private val TAG = "google login"
 
-    private fun saveToken(response: RegisterResponse){
+    private fun saveToken(response: SignInResponse){
         GCMSApplication.prefs.apply {
             accessToken = response.accessToken
             refreshToken = response.refreshToken

--- a/app/src/main/java/com/msg/gcms/ui/component/intro/component/ProgressDialog.kt
+++ b/app/src/main/java/com/msg/gcms/ui/component/intro/component/ProgressDialog.kt
@@ -1,4 +1,4 @@
-package com.msg.gcms.ui.component.intro.Component
+package com.msg.gcms.ui.component.intro.component
 
 import android.app.Dialog
 import android.content.Context

--- a/app/src/main/res/layout/activity_intro.xml
+++ b/app/src/main/res/layout/activity_intro.xml
@@ -178,16 +178,6 @@
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toEndOf="@+id/view10" />
 
-        <ProgressBar
-            android:visibility="invisible"
-            android:id="@+id/progressBar"
-            android:layout_width="100dp"
-            android:layout_height="100dp"
-            app:layout_constraintBottom_toBottomOf="@+id/gAuthWebView"
-            app:layout_constraintEnd_toEndOf="@+id/gAuthWebView"
-            app:layout_constraintStart_toStartOf="@+id/gAuthWebView"
-            app:layout_constraintTop_toTopOf="parent" />
-
         <androidx.compose.ui.platform.ComposeView
             android:id="@+id/signInBtn"
             android:layout_width="0dp"

--- a/app/src/main/res/layout/activity_intro.xml
+++ b/app/src/main/res/layout/activity_intro.xml
@@ -178,6 +178,15 @@
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toEndOf="@+id/view10" />
 
+        <ProgressBar
+            android:visibility="invisible"
+            android:id="@+id/progressBar"
+            android:layout_width="100dp"
+            android:layout_height="100dp"
+            app:layout_constraintBottom_toBottomOf="@+id/gAuthWebView"
+            app:layout_constraintEnd_toEndOf="@+id/gAuthWebView"
+            app:layout_constraintStart_toStartOf="@+id/gAuthWebView"
+            app:layout_constraintTop_toTopOf="parent" />
 
         <androidx.compose.ui.platform.ComposeView
             android:id="@+id/signInBtn"


### PR DESCRIPTION
## PR 정보
- 로그인 방식을 GAuth로 변경합니다

## 작업 결과
- 로그인 방식을 라이브러리를 사용하여 GAuth방식으로 변경했습니다
- GAuthWebView에서 code를 받아 code를 사용하여 토큰에 관한 정보를 받아옵니다
- 받아온 토큰관련 정보들을 로컬에 저장합니다

## 주요코드
- 토큰을 받아와서 예외처리 후 토큰 저장
https://github.com/GSM-MSG/GCMS-Android/blob/8390bafc9ca72d3a37b536c57d048a42a3bdc4aa/app/src/main/java/com/msg/gcms/presentation/viewmodel/AuthViewModel.kt#L31-L54
