### PR TITLE
🔀 :: (#228) 화면 전환 애니메이션 적용

### DIFF
--- a/app/src/main/java/com/msg/gcms/presentation/utils/ChangeScreenEvent.kt
+++ b/app/src/main/java/com/msg/gcms/presentation/utils/ChangeScreenEvent.kt
@@ -1,0 +1,29 @@
+package com.msg.gcms.presentation.utils
+
+import android.app.Activity
+import android.content.Intent
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentActivity
+import com.msg.gcms.R
+
+fun enterActivity(activity: FragmentActivity, destination: Activity) {
+    activity.startActivity(Intent(activity, destination::class.java))
+    activity.overridePendingTransition(R.anim.enter_anim, R.anim.no_anim)
+}
+
+fun exitActivity(activity: FragmentActivity) {
+    activity.finish()
+    activity.overridePendingTransition(R.anim.no_anim, R.anim.exit_anim)
+}
+
+fun enterFragment(activity: FragmentActivity, fragmentContainer: Int, destination: Fragment) {
+    activity.supportFragmentManager.beginTransaction()
+        .setCustomAnimations(R.anim.enter_anim, R.anim.no_anim)
+        .replace(fragmentContainer, destination).commit()
+}
+
+fun exitFragment(activity: FragmentActivity, fragmentContainer: Int, destination: Fragment) {
+    activity.supportFragmentManager.beginTransaction()
+        .setCustomAnimations(R.anim.no_anim, R.anim.exit_anim)
+        .replace(fragmentContainer, destination).commit()
+}

--- a/app/src/main/java/com/msg/gcms/presentation/view/club/ClubFragment.kt
+++ b/app/src/main/java/com/msg/gcms/presentation/view/club/ClubFragment.kt
@@ -8,6 +8,9 @@ import com.msg.gcms.databinding.FragmentClubBinding
 import com.msg.gcms.presentation.adapter.ClubListAdapter
 import com.msg.gcms.presentation.base.BaseFragment
 import com.msg.gcms.presentation.base.BaseModal
+import com.msg.gcms.presentation.utils.enterActivity
+import com.msg.gcms.presentation.utils.enterFragment
+import com.msg.gcms.presentation.utils.exitFragment
 import com.msg.gcms.presentation.view.club.detail.DetailFragment
 import com.msg.gcms.presentation.view.clubmaker.MakeClubActivity
 import com.msg.gcms.presentation.view.profile.ProfileActivity
@@ -59,17 +62,13 @@ class ClubFragment : BaseFragment<FragmentClubBinding>(R.layout.fragment_club) {
 
     private fun clickProfile() {
         binding.profileBtn.setOnClickListener {
-            val intent = Intent(activity, ProfileActivity::class.java)
-            intent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
-            startActivity(intent)
+            enterActivity(requireActivity(), ProfileActivity())
         }
     }
 
     private fun clickMakeClubBtn() {
         binding.addClubBtn.setOnClickListener {
-            val intent = Intent(activity, MakeClubActivity::class.java)
-            intent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
-            startActivity(intent)
+            enterActivity(requireActivity(), MakeClubActivity())
         }
     }
 
@@ -98,13 +97,11 @@ class ClubFragment : BaseFragment<FragmentClubBinding>(R.layout.fragment_club) {
         }*/
     }
 
-
     private fun observeClubDetailInfo() {
         detailViewModel.getClubDetail.observe(this) {
-            when(it) {
+            when (it) {
                 Event.Success -> {
-                    requireActivity().supportFragmentManager.beginTransaction()
-                        .replace(R.id.fragment_club, DetailFragment()).commit()
+                    enterFragment(requireActivity(), R.id.fragment_club, DetailFragment())
                 }
                 Event.BadRequest -> {
                     shortToast("동아리 정보를 불러오지 못했습니다.")

--- a/app/src/main/java/com/msg/gcms/presentation/view/club/detail/DetailFragment.kt
+++ b/app/src/main/java/com/msg/gcms/presentation/view/club/detail/DetailFragment.kt
@@ -1,8 +1,10 @@
 package com.msg.gcms.presentation.view.club.detail
 
+import android.content.Context
 import android.content.Intent
 import android.util.Log
 import android.view.View
+import androidx.activity.OnBackPressedCallback
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.activityViewModels
 import androidx.recyclerview.widget.GridLayoutManager
@@ -42,6 +44,7 @@ class DetailFragment : BaseFragment<FragmentDetailBinding>(R.layout.fragment_det
     private val TAG = "DetailFragment"
     private val detailViewModel by activityViewModels<ClubDetailViewModel>()
     private val clubViewModel by activityViewModels<ClubViewModel>()
+    private lateinit var callback: OnBackPressedCallback
     var membersList = mutableListOf<MemberSummaryResponse>()
     var activityUrlsList = mutableListOf<PromotionPicType>()
     private val detailMemberAdapter = DetailMemberAdapter()
@@ -58,6 +61,21 @@ class DetailFragment : BaseFragment<FragmentDetailBinding>(R.layout.fragment_det
         DetailPageSideBar("동아리 멤버 확인하기", R.drawable.ic_person_two),
         DetailPageSideBar("동아리 탈퇴하기", R.drawable.ic_club_delete)
     )
+
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+        callback = object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                exitActivity(requireActivity())
+            }
+        }
+        requireActivity().onBackPressedDispatcher.addCallback(this, callback)
+    }
+
+    override fun onDetach() {
+        super.onDetach()
+        callback.remove()
+    }
 
     override fun init() {
         observeEvent()

--- a/app/src/main/java/com/msg/gcms/presentation/view/club/detail/DetailFragment.kt
+++ b/app/src/main/java/com/msg/gcms/presentation/view/club/detail/DetailFragment.kt
@@ -22,6 +22,9 @@ import com.msg.gcms.presentation.base.BaseDialog
 import com.msg.gcms.presentation.base.BaseFragment
 import com.msg.gcms.presentation.base.BaseModal
 import com.msg.gcms.presentation.utils.ItemDecorator
+import com.msg.gcms.presentation.utils.enterActivity
+import com.msg.gcms.presentation.utils.exitActivity
+import com.msg.gcms.presentation.utils.exitFragment
 import com.msg.gcms.presentation.view.club.ClubFragment
 import com.msg.gcms.presentation.view.editclub.EditClubActivity
 import com.msg.gcms.presentation.view.main.MainActivity
@@ -119,12 +122,10 @@ class DetailFragment : BaseFragment<FragmentDetailBinding>(R.layout.fragment_det
 
     private fun goBack() {
         if (detailViewModel.isProfile.value == true) {
-            val intent = Intent(requireActivity(), ProfileActivity::class.java)
-            startActivity(intent)
+            exitActivity(requireActivity())
         } else {
             detailViewModel.setNav(true)
-            requireActivity().supportFragmentManager.beginTransaction()
-                .replace(R.id.fragment_club, ClubFragment()).commit()
+            exitFragment(requireActivity(), R.id.fragment_club, ClubFragment())
         }
         detailViewModel.setIsProfile(false)
     }

--- a/app/src/main/java/com/msg/gcms/presentation/view/clubmaker/clubType/ClubTypeFragment.kt
+++ b/app/src/main/java/com/msg/gcms/presentation/view/clubmaker/clubType/ClubTypeFragment.kt
@@ -1,6 +1,8 @@
 package com.msg.gcms.presentation.view.clubmaker.clubType
 
+import android.content.Context
 import android.view.View
+import androidx.activity.OnBackPressedCallback
 import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
 import com.msg.gcms.R
@@ -14,12 +16,28 @@ import dagger.hilt.android.AndroidEntryPoint
 class ClubTypeFragment : BaseFragment<FragmentClubTypeBinding>(R.layout.fragment_club_type) {
 
     private val makeClubViewModel by activityViewModels<MakeClubViewModel>()
+    private lateinit var callback: OnBackPressedCallback
+
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+        callback = object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                exitActivity(requireActivity())
+            }
+        }
+        requireActivity().onBackPressedDispatcher.addCallback(this, callback)
+    }
+
+    override fun onDetach() {
+        super.onDetach()
+        callback.remove()
+    }
 
     override fun init() {
         binding.fragment = this
     }
 
-    private lateinit var clubType : String
+    private lateinit var clubType: String
 
     fun whenClickedBtn(view: View) {
         if (view.id != binding.clubTypeBackBtn.id) {

--- a/app/src/main/java/com/msg/gcms/presentation/view/clubmaker/clubType/ClubTypeFragment.kt
+++ b/app/src/main/java/com/msg/gcms/presentation/view/clubmaker/clubType/ClubTypeFragment.kt
@@ -6,6 +6,7 @@ import androidx.navigation.fragment.findNavController
 import com.msg.gcms.R
 import com.msg.gcms.databinding.FragmentClubTypeBinding
 import com.msg.gcms.presentation.base.BaseFragment
+import com.msg.gcms.presentation.utils.exitActivity
 import com.msg.gcms.presentation.viewmodel.MakeClubViewModel
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -31,7 +32,7 @@ class ClubTypeFragment : BaseFragment<FragmentClubTypeBinding>(R.layout.fragment
 
             this.findNavController().navigate(R.id.action_clubTypeFragment_to_clubIntroduceFragment)
         } else if (view.id == binding.clubTypeBackBtn.id) {
-            activity?.finish()
+            exitActivity(requireActivity())
         }
     }
 }

--- a/app/src/main/java/com/msg/gcms/presentation/view/intro/IntroActivity.kt
+++ b/app/src/main/java/com/msg/gcms/presentation/view/intro/IntroActivity.kt
@@ -25,6 +25,7 @@ class IntroActivity : BaseActivity<ActivityIntroBinding>(R.layout.activity_intro
     private val viewModel by viewModels<AuthViewModel>()
 
     override fun viewSetting() {
+        binding.login = this
         progressDialog = ProgressDialog(this)
         setGAuthButtonComponent()
     }

--- a/app/src/main/java/com/msg/gcms/presentation/view/profile/ProfileActivity.kt
+++ b/app/src/main/java/com/msg/gcms/presentation/view/profile/ProfileActivity.kt
@@ -16,6 +16,7 @@ import com.google.android.material.snackbar.Snackbar
 import com.msg.gcms.R
 import com.msg.gcms.databinding.ActivityProfileBinding
 import com.msg.gcms.presentation.base.BaseActivity
+import com.msg.gcms.presentation.utils.exitActivity
 import com.msg.gcms.presentation.view.main.MainActivity
 import com.msg.gcms.presentation.view.withdrawal.WithdrawalDialog
 import com.msg.gcms.presentation.viewmodel.ProfileViewModel
@@ -72,13 +73,13 @@ class ProfileActivity : BaseActivity<ActivityProfileBinding>(R.layout.activity_p
 
     private fun clickBackBtn() {
         binding.backBtn.setOnClickListener {
-            startActivity(Intent(this, MainActivity::class.java))
+            exitActivity(this)
         }
     }
 
     override fun onBackPressed() {
         super.onBackPressed()
-        startActivity(Intent(this, MainActivity::class.java))
+        exitActivity(this)
     }
 
     private fun clickProfileEdit() {

--- a/app/src/main/res/anim/enter_anim.xml
+++ b/app/src/main/res/anim/enter_anim.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<translate xmlns:android="http://schemas.android.com/apk/res/android"
+    android:duration="200"
+    android:fromXDelta="100%"
+    android:toXDelta="0%" />

--- a/app/src/main/res/anim/exit_anim.xml
+++ b/app/src/main/res/anim/exit_anim.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<translate xmlns:android="http://schemas.android.com/apk/res/android"
+    android:duration="200"
+    android:fromXDelta="0%"
+    android:toXDelta="100%" />

--- a/app/src/main/res/anim/no_anim.xml
+++ b/app/src/main/res/anim/no_anim.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+
+</set>

--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -16,7 +16,7 @@ object Versions {
     const val CORE_KTX = "1.5.0"
     const val APP_COMPAT = "1.4.1"
     const val ACTIVITY_KTX = "1.2.3"
-    const val FRAGMENT_KTX = "1.3.4"
+    const val FRAGMENT_KTX = "1.5.4"
     const val LIFECYCLE_KTX = "2.3.1"
     const val ROOM = "2.3.0"
     const val LEGACY = "1.0.0"


### PR DESCRIPTION
## PR 정보
화면 간 이동 시 페이지가 옆으로 넘어가는 애니메이션을 적용하였습니다.

## 작업 결과
- detail, profile, makeClub화면 진입할 때와 나올 때 애니메이션을 적용하였습니다.

## 주요코드
- fragment와 activity의 화면 전환 시 애니메이션 적용하는 코드를 함께 함수화 시켰습니다.
https://github.com/GSM-MSG/GCMS-Android/blob/a0014b51dccb5948f8bc6cb23c3871a5b4394d98/app/src/main/java/com/msg/gcms/presentation/utils/ChangeScreenEvent.kt#L9-L29
- fragment에서 activity를 종료 시킬때는 callback을 만들어 onBackPressedDispatcher에 추가하였습니다.
https://github.com/GSM-MSG/GCMS-Android/blob/a0014b51dccb5948f8bc6cb23c3871a5b4394d98/app/src/main/java/com/msg/gcms/presentation/view/clubmaker/clubType/ClubTypeFragment.kt#L19-L34


