### PR TITLE
🔀 :: (#293) 파일 관련 util로 관리

### DIFF
--- a/app/src/main/java/com/msg/gcms/presentation/utils/FileUtil.kt
+++ b/app/src/main/java/com/msg/gcms/presentation/utils/FileUtil.kt
@@ -8,6 +8,9 @@ import android.net.Uri
 import android.os.Build
 import android.os.Environment
 import android.provider.MediaStore
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.MultipartBody
+import okhttp3.RequestBody.Companion.asRequestBody
 import java.io.File
 import java.io.FileOutputStream
 
@@ -33,6 +36,13 @@ fun Uri.uriToBitMap(context: Context): Bitmap {
     }
     return bitmap
 }
+
+fun File.toMultiPartBody(): MultipartBody.Part =
+    MultipartBody.Part.createFormData(
+        name = "files",
+        filename = this.name,
+        body = this.asRequestBody("image/*".toMediaType())
+    )
 
 private fun Uri.getFileName(context: Context): String {
     val name = this.toString().split("/").last()

--- a/app/src/main/java/com/msg/gcms/presentation/view/clubmaker/club_detail/MakeClubDetailFragment.kt
+++ b/app/src/main/java/com/msg/gcms/presentation/view/clubmaker/club_detail/MakeClubDetailFragment.kt
@@ -28,14 +28,13 @@ import com.msg.gcms.presentation.base.BaseFragment
 import com.msg.gcms.presentation.base.BaseModal
 import com.msg.gcms.presentation.utils.ItemDecorator
 import com.msg.gcms.presentation.utils.toFile
+import com.msg.gcms.presentation.utils.toMultiPartBody
 import com.msg.gcms.presentation.utils.uriToBitMap
 import com.msg.gcms.presentation.viewmodel.ClubViewModel
 import com.msg.gcms.presentation.viewmodel.MakeClubViewModel
 import com.msg.gcms.presentation.viewmodel.util.Event
 import dagger.hilt.android.AndroidEntryPoint
-import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.MultipartBody
-import okhttp3.RequestBody
 
 @AndroidEntryPoint
 class MakeClubDetailFragment :
@@ -128,10 +127,8 @@ class MakeClubDetailFragment :
         registerForActivityResult(ActivityResultContracts.GetContent()) { imageUri ->
             if (imageUri != null) {
                 val file = imageUri.toFile(requireContext())
-                val requestFile = RequestBody.create("image/*".toMediaTypeOrNull(), file)
-                val img = MultipartBody.Part.createFormData("file", file.name, requestFile)
-                bannerImage.add(img)
-                bannerImageUri = imageUri!!
+                bannerImage.add(file.toMultiPartBody())
+                bannerImageUri = imageUri
 
                 with(binding.addBannerPicture) {
                     setImageURI(imageUri)
@@ -245,10 +242,7 @@ class MakeClubDetailFragment :
                         makeClubViewModel.activityPhotoList.add(ActivityPhotoType(activityPhoto = imageBitmap))
                         Log.d("TAG", "getBitmap: $imageBitmap")
                         val file = imageUri.toFile(requireContext())
-                        val requestFile = RequestBody.create("image/*".toMediaTypeOrNull(), file)
-                        val img = MultipartBody.Part.createFormData("file", file.name, requestFile)
-                        Log.d("TAG", "onActivityResult: $img")
-                        activityPhotoMultipart.add(img)
+                        activityPhotoMultipart.add(file.toMultiPartBody())
                     }
                     Log.d("TAG", "finallyImage: ${makeClubViewModel.activityPhotoList.size}")
                     binding.clubActivePicture.adapter = activityAdapter

--- a/app/src/main/java/com/msg/gcms/presentation/view/editclub/EditClubFragment.kt
+++ b/app/src/main/java/com/msg/gcms/presentation/view/editclub/EditClubFragment.kt
@@ -35,14 +35,13 @@ import com.msg.gcms.presentation.base.BaseFragment
 import com.msg.gcms.presentation.base.BaseModal
 import com.msg.gcms.presentation.utils.ItemDecorator
 import com.msg.gcms.presentation.utils.toFile
+import com.msg.gcms.presentation.utils.toMultiPartBody
 import com.msg.gcms.presentation.utils.uriToBitMap
 import com.msg.gcms.presentation.viewmodel.EditViewModel
 import com.msg.gcms.presentation.viewmodel.util.Event
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
-import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.MultipartBody
-import okhttp3.RequestBody
 import java.io.File
 import java.io.FileOutputStream
 import java.io.OutputStream
@@ -79,10 +78,7 @@ class EditClubFragment : BaseFragment<FragmentEditClubBinding>(R.layout.fragment
         registerForActivityResult(ActivityResultContracts.GetContent()) { imageUri ->
             if (imageUri != null) {
                 val file = imageUri.toFile(requireContext())
-                val requestFile = RequestBody.create("image/*".toMediaTypeOrNull(), file)
-                val img = MultipartBody.Part.createFormData("files", file.name, requestFile)
-                Log.d("TAG", "onActivityResult: $img")
-                bannerImage = img
+                bannerImage = file.toMultiPartBody()
                 bannerImageUri = imageUri
                 with(binding) {
                     bannerImageView.load(imageUri) {
@@ -106,12 +102,8 @@ class EditClubFragment : BaseFragment<FragmentEditClubBinding>(R.layout.fragment
                         val imageUri: Uri = data.clipData!!.getItemAt(i).uri
                         val imageBitmap = imageUri.uriToBitMap(requireContext())
                         activityPhotoList.add(ActivityPhotoType(activityPhoto = imageBitmap))
-                        Log.d("TAG", "getBitmap: $imageBitmap")
                         val file = imageUri.toFile(requireContext())
-                        val requestFile = RequestBody.create("image/*".toMediaTypeOrNull(), file)
-                        val img = MultipartBody.Part.createFormData("files", file.name, requestFile)
-                        Log.d("TAG", "onActivityResult: $img")
-                        activityPhotoMultipart.add(img)
+                        activityPhotoMultipart.add(file.toMultiPartBody())
                     }
                     Log.d("TAG", "activityPhotoList: $activityPhotoList")
                     activityAdapter.notifyDataSetChanged()
@@ -359,10 +351,8 @@ class EditClubFragment : BaseFragment<FragmentEditClubBinding>(R.layout.fragment
                 it.activityPhoto.compress(Bitmap.CompressFormat.JPEG, 100, stream)
                 stream.flush()
                 stream.close()
-                val requestFile = RequestBody.create("image/*".toMediaTypeOrNull(), file)
-                val img = MultipartBody.Part.createFormData("files", file.name, requestFile)
 
-                imgList.add(img)
+                imgList.add(file.toMultiPartBody())
                 Log.d("TAG", "convertBitmapToMultiPart: $imgList")
             } catch (e: Exception) {
                 e.printStackTrace()
@@ -379,20 +369,16 @@ class EditClubFragment : BaseFragment<FragmentEditClubBinding>(R.layout.fragment
         val wrapper = ContextWrapper(context)
         var file = wrapper.getDir("images", Context.MODE_PRIVATE)
         file = File(file, "${UUID.randomUUID()}.jpg}")
-        lateinit var image: MultipartBody.Part
 
         try {
             val stream: OutputStream = FileOutputStream(file)
             bitmap.compress(Bitmap.CompressFormat.JPEG, 100, stream)
             stream.flush()
             stream.close()
-            val requestFile = RequestBody.create("image/*".toMediaTypeOrNull(), file)
-            image = MultipartBody.Part.createFormData("files", file.name, requestFile)
-            Log.d("TAG", "convertBitmapToMultiPart: $image")
         } catch (e: Exception) {
             e.printStackTrace()
         }
-        return image
+        return file.toMultiPartBody()
     }
 
     //TODO 동아리 수정 로직 변경된거 수정하기

--- a/app/src/main/java/com/msg/gcms/presentation/view/profile/ProfileActivity.kt
+++ b/app/src/main/java/com/msg/gcms/presentation/view/profile/ProfileActivity.kt
@@ -16,15 +16,13 @@ import com.msg.gcms.presentation.base.BaseActivity
 import com.msg.gcms.presentation.utils.enterActivity
 import com.msg.gcms.presentation.utils.exitActivity
 import com.msg.gcms.presentation.utils.toFile
+import com.msg.gcms.presentation.utils.toMultiPartBody
 import com.msg.gcms.presentation.view.intro.IntroActivity
 import com.msg.gcms.presentation.view.withdrawal.WithdrawalActivity
 import com.msg.gcms.presentation.view.withdrawal.WithdrawalDialog
 import com.msg.gcms.presentation.viewmodel.AuthViewModel
 import com.msg.gcms.presentation.viewmodel.ProfileViewModel
 import dagger.hilt.android.AndroidEntryPoint
-import okhttp3.MediaType.Companion.toMediaTypeOrNull
-import okhttp3.MultipartBody
-import okhttp3.RequestBody
 
 @AndroidEntryPoint
 class ProfileActivity : BaseActivity<ActivityProfileBinding>(R.layout.activity_profile) {
@@ -38,9 +36,7 @@ class ProfileActivity : BaseActivity<ActivityProfileBinding>(R.layout.activity_p
                     transformations(CircleCropTransformation())
                 }
                 val file = imageUri.toFile(this)
-                val requestFile = RequestBody.create("image/*".toMediaTypeOrNull(), file)
-                val img = MultipartBody.Part.createFormData("files", file.name, requestFile)
-                profileViewModel.uploadImg(img)
+                profileViewModel.uploadImg(file.toMultiPartBody())
             }
         }
 


### PR DESCRIPTION
## PR 정보
- 파일 관련한 함수들을 util로 관리합니다. (uri to file, uri to bitmap, file to multipartbody)
- 갤러리 이미지 받아오는 부분을 안드로이드 정책에 맞게 변경합니다.

## 작업 결과
- uri to file code
https://github.com/GSM-MSG/GCMS-Android/blob/1b9d53df4cd0dfe6a39d7ed0af9733d5740283dd/app/src/main/java/com/msg/gcms/presentation/utils/FileUtil.kt#L18-L24
https://github.com/GSM-MSG/GCMS-Android/blob/1b9d53df4cd0dfe6a39d7ed0af9733d5740283dd/app/src/main/java/com/msg/gcms/presentation/utils/FileUtil.kt#L47-L70
- uri to bitmap code
https://github.com/GSM-MSG/GCMS-Android/blob/1b9d53df4cd0dfe6a39d7ed0af9733d5740283dd/app/src/main/java/com/msg/gcms/presentation/utils/FileUtil.kt#L26-L38
- uri to multipartbody code
https://github.com/GSM-MSG/GCMS-Android/blob/1b9d53df4cd0dfe6a39d7ed0af9733d5740283dd/app/src/main/java/com/msg/gcms/presentation/utils/FileUtil.kt#L40-L45