### PR TITLE
🔀 :: (#291) - change the logic that modify activity photo

### DIFF
--- a/app/src/main/java/com/msg/gcms/presentation/view/editclub/EditClubFragment.kt
+++ b/app/src/main/java/com/msg/gcms/presentation/view/editclub/EditClubFragment.kt
@@ -121,7 +121,7 @@ class EditClubFragment : BaseFragment<FragmentEditClubBinding>(R.layout.fragment
                         activityPhotoMultipart.add(file.toMultiPartBody())
                     }
                     Log.d("TAG", "activityPhotoList: $activityPhotoList")
-                    activityAdapter.notifyDataSetChanged()
+                    activityPhotoRecyclerViewUpdater(activityPhotoList)
                 }
             }
         }

--- a/app/src/main/java/com/msg/gcms/presentation/view/editclub/EditClubFragment.kt
+++ b/app/src/main/java/com/msg/gcms/presentation/view/editclub/EditClubFragment.kt
@@ -276,23 +276,6 @@ class EditClubFragment : BaseFragment<FragmentEditClubBinding>(R.layout.fragment
             override fun onClick(position: Int) {
                 activityPhotoList.removeAt(position)
                 activityPhotoRecyclerViewUpdater(activityPhotoList)
-                // if (activityPhotoUrlList.size >= position + 1) activityPhotoUrlList.removeAt(
-                //     position
-                // )
-                // Log.d(
-                //     "TAG",
-                //     "activityPhotoUrlList: $activityPhotoUrlList, newList: ${
-                //         activityPhotoList.filter {
-                //             !legacyList.contains(it)
-                //         }
-                //     }, removed: ${
-                //         editViewModel.clubInfo.value!!.activityImgs.filter {
-                //             !activityPhotoUrlList.contains(
-                //                 it
-                //             )
-                //         }
-                //     }"
-                // )
             }
         })
         binding.clubActivePictureRv.adapter = activityAdapter

--- a/app/src/main/java/com/msg/gcms/presentation/view/editclub/EditClubFragment.kt
+++ b/app/src/main/java/com/msg/gcms/presentation/view/editclub/EditClubFragment.kt
@@ -275,23 +275,24 @@ class EditClubFragment : BaseFragment<FragmentEditClubBinding>(R.layout.fragment
             ActivityPhotosAdapter.OnItemClickListener {
             override fun onClick(position: Int) {
                 activityPhotoList.removeAt(position)
-                if (activityPhotoUrlList.size >= position + 1) activityPhotoUrlList.removeAt(
-                    position
-                )
-                Log.d(
-                    "TAG",
-                    "activityPhotoUrlList: $activityPhotoUrlList, newList: ${
-                        activityPhotoList.filter {
-                            !legacyList.contains(it)
-                        }
-                    }, removed: ${
-                        editViewModel.clubInfo.value!!.activityImgs.filter {
-                            !activityPhotoUrlList.contains(
-                                it
-                            )
-                        }
-                    }"
-                )
+                activityPhotoRecyclerViewUpdater(activityPhotoList)
+                // if (activityPhotoUrlList.size >= position + 1) activityPhotoUrlList.removeAt(
+                //     position
+                // )
+                // Log.d(
+                //     "TAG",
+                //     "activityPhotoUrlList: $activityPhotoUrlList, newList: ${
+                //         activityPhotoList.filter {
+                //             !legacyList.contains(it)
+                //         }
+                //     }, removed: ${
+                //         editViewModel.clubInfo.value!!.activityImgs.filter {
+                //             !activityPhotoUrlList.contains(
+                //                 it
+                //             )
+                //         }
+                //     }"
+                // )
             }
         })
         binding.clubActivePictureRv.adapter = activityAdapter

--- a/app/src/main/java/com/msg/gcms/presentation/view/editclub/EditClubFragment.kt
+++ b/app/src/main/java/com/msg/gcms/presentation/view/editclub/EditClubFragment.kt
@@ -117,6 +117,7 @@ class EditClubFragment : BaseFragment<FragmentEditClubBinding>(R.layout.fragment
                         val imageUri: Uri = data.clipData!!.getItemAt(i).uri
                         val imageBitmap = imageUri.uriToBitMap(requireContext())
                         activityPhotoList.add(ActivityPhotoType(activityPhoto = imageBitmap))
+                        activityPhotoRecyclerViewUpdater(activityPhotoList)
                         val file = imageUri.toFile(requireContext())
                         activityPhotoMultipart.add(file.toMultiPartBody())
                     }
@@ -238,8 +239,9 @@ class EditClubFragment : BaseFragment<FragmentEditClubBinding>(R.layout.fragment
                         activityPhotoUrlList = it.activityImgs.toMutableList()
                         memberRecyclerviewUpdater(clubMemberChecker(it.member))
                         lifecycleScope.launch {
-                            activityPhotoRecyclerViewUpdater(addBitmapToList(it.activityImgs))
-                            bannerImageBitmap = getBitmapFromUrl(it.bannerImg)
+                            val activityPhotoList = addBitmapToList(it.activityImgs)
+                            this@EditClubFragment.activityPhotoList.addAll(activityPhotoList)
+                            activityPhotoRecyclerViewUpdater(activityPhotoList)
                         }
                     }
                 }


### PR DESCRIPTION
## PR 정보
동아리 정보 수정 시 이미지 변경 가능하도록 기능을 추가합니다.

## 작업 결과

https://user-images.githubusercontent.com/82383983/221354651-4419c755-580f-4e1b-85ff-d3f5fa63f4a5.mp4
