### PR TITLE
🔀 :: (#298) - 디테일 페이지 핫픽스

### DIFF
--- a/app/src/main/java/com/msg/gcms/presentation/view/club/detail/DetailFragment.kt
+++ b/app/src/main/java/com/msg/gcms/presentation/view/club/detail/DetailFragment.kt
@@ -78,8 +78,8 @@ class DetailFragment : BaseFragment<FragmentDetailBinding>(R.layout.fragment_det
 
     override fun onStop() {
         super.onStop()
-        detailViewModel.clear()
-        clubViewModel.clear()
+        detailViewModel.initializationProperties()
+        clubViewModel.initializationProperties()
     }
 
     override fun init() {
@@ -422,7 +422,6 @@ class DetailFragment : BaseFragment<FragmentDetailBinding>(R.layout.fragment_det
                 Event.NotFound -> {
                     BaseModal("오류", "동아리를 찾을 수 없습니다.", requireContext()).show()
                 }
-                null -> {}
                 else -> {
                     BaseModal("오류", "알 수 없는 오류 발생, 개발자에게 문의해주세요.", requireContext()).show()
                 }
@@ -444,7 +443,6 @@ class DetailFragment : BaseFragment<FragmentDetailBinding>(R.layout.fragment_det
                 Event.NotFound -> {
                     BaseModal("오류", "동아리를 찾을 수 없습니다.", requireContext()).show()
                 }
-                null -> {}
                 else -> {
                     BaseModal("오류", "알 수 없는 오류 발생, 개발자에게 문의해주세요.", requireContext()).show()
                 }
@@ -469,7 +467,6 @@ class DetailFragment : BaseFragment<FragmentDetailBinding>(R.layout.fragment_det
                 Event.NotFound -> {
                     BaseModal("오류", "동아리를 찾을 수 없습니다.", requireContext()).show()
                 }
-                null -> {}
                 else -> {
                     BaseModal("오류", "알수 없는 오류 발생, 개발자에게 문의해주세요.", requireContext()).show()
                 }
@@ -494,7 +491,6 @@ class DetailFragment : BaseFragment<FragmentDetailBinding>(R.layout.fragment_det
                 Event.NotFound -> {
                     BaseModal("오류", "동아리를 찾을 수 없습니다.", requireContext()).show()
                 }
-                null -> {}
                 else -> {
                     BaseModal("오류", "알수 없는 오류 발생, 개발자에게 문의해주세요.", requireContext()).show()
                 }

--- a/app/src/main/java/com/msg/gcms/presentation/view/club/detail/DetailFragment.kt
+++ b/app/src/main/java/com/msg/gcms/presentation/view/club/detail/DetailFragment.kt
@@ -408,7 +408,6 @@ class DetailFragment : BaseFragment<FragmentDetailBinding>(R.layout.fragment_det
     private fun observeApplyClubEvent() {
         clubViewModel.applyClub.observe(this) { status ->
             detailViewModel.refreshDetailInfo(detailViewModel.result.value!!.id)
-            Log.d("ApplyClub", "observe")
             when (status) {
                 Event.Success -> {
                     BaseModal("성공", "동아리 신청에 성공했습니다.", requireContext()).show()
@@ -432,7 +431,6 @@ class DetailFragment : BaseFragment<FragmentDetailBinding>(R.layout.fragment_det
     private fun observeCancelClubEvent() {
         clubViewModel.cancelClubApply.observe(this) { status ->
             detailViewModel.refreshDetailInfo(detailViewModel.result.value!!.id)
-            Log.d("CancelClubApply", "observe")
             when (status) {
                 Event.Success -> {
                     BaseModal("성공", "동아리 신청을 취소했습니다.", requireContext()).show()
@@ -453,7 +451,6 @@ class DetailFragment : BaseFragment<FragmentDetailBinding>(R.layout.fragment_det
     private fun observeOpenClubApplyEvent() {
         clubViewModel.openingClubApplication.observe(this) { status ->
             detailViewModel.refreshDetailInfo(detailViewModel.result.value!!.id)
-            Log.d("OpeningClubApplication", "observe")
             when (status) {
                 Event.Success -> {
                     BaseModal("성공", "동아리 신청을 오픈했습니다.", requireContext()).show()
@@ -477,7 +474,6 @@ class DetailFragment : BaseFragment<FragmentDetailBinding>(R.layout.fragment_det
     private fun observeCloseClubApplyEvent() {
         clubViewModel.closingClubApplication.observe(this) { status ->
             detailViewModel.refreshDetailInfo(detailViewModel.result.value!!.id)
-            Log.d("closingClubApplication", "observe")
             when (status) {
                 Event.Success -> {
                     BaseModal("성공", "동아리 신청을 마감했습니다.", requireContext()).show()

--- a/app/src/main/java/com/msg/gcms/presentation/view/club/detail/DetailFragment.kt
+++ b/app/src/main/java/com/msg/gcms/presentation/view/club/detail/DetailFragment.kt
@@ -76,6 +76,11 @@ class DetailFragment : BaseFragment<FragmentDetailBinding>(R.layout.fragment_det
         callback.remove()
     }
 
+    override fun onStop() {
+        super.onStop()
+        detailViewModel.clear()
+    }
+
     override fun init() {
         observeEvent()
         clickEvent()
@@ -84,7 +89,6 @@ class DetailFragment : BaseFragment<FragmentDetailBinding>(R.layout.fragment_det
     }
 
     private fun observeEvent() {
-        observeStatus()
         observeResult()
     }
 
@@ -211,6 +215,8 @@ class DetailFragment : BaseFragment<FragmentDetailBinding>(R.layout.fragment_det
     private fun clickSubmitBtn() {
         binding.submitBtn.setOnClickListener {
             changeDialog()
+            clubViewModel.clear()
+            observeStatus()
         }
     }
 
@@ -402,6 +408,7 @@ class DetailFragment : BaseFragment<FragmentDetailBinding>(R.layout.fragment_det
     private fun observeApplyClubEvent() {
         clubViewModel.applyClub.observe(this) { status ->
             detailViewModel.refreshDetailInfo(detailViewModel.result.value!!.id)
+            Log.d("ApplyClub", "observe")
             when (status) {
                 Event.Success -> {
                     BaseModal("성공", "동아리 신청에 성공했습니다.", requireContext()).show()
@@ -415,6 +422,7 @@ class DetailFragment : BaseFragment<FragmentDetailBinding>(R.layout.fragment_det
                 Event.NotFound -> {
                     BaseModal("오류", "동아리를 찾을 수 없습니다.", requireContext()).show()
                 }
+                null -> {}
                 else -> {
                     BaseModal("오류", "알 수 없는 오류 발생, 개발자에게 문의해주세요.", requireContext()).show()
                 }
@@ -425,6 +433,7 @@ class DetailFragment : BaseFragment<FragmentDetailBinding>(R.layout.fragment_det
     private fun observeCancelClubEvent() {
         clubViewModel.cancelClubApply.observe(this) { status ->
             detailViewModel.refreshDetailInfo(detailViewModel.result.value!!.id)
+            Log.d("CancelClubApply", "observe")
             when (status) {
                 Event.Success -> {
                     BaseModal("성공", "동아리 신청을 취소했습니다.", requireContext()).show()
@@ -435,6 +444,7 @@ class DetailFragment : BaseFragment<FragmentDetailBinding>(R.layout.fragment_det
                 Event.NotFound -> {
                     BaseModal("오류", "동아리를 찾을 수 없습니다.", requireContext()).show()
                 }
+                null -> {}
                 else -> {
                     BaseModal("오류", "알 수 없는 오류 발생, 개발자에게 문의해주세요.", requireContext()).show()
                 }
@@ -445,6 +455,7 @@ class DetailFragment : BaseFragment<FragmentDetailBinding>(R.layout.fragment_det
     private fun observeOpenClubApplyEvent() {
         clubViewModel.openingClubApplication.observe(this) { status ->
             detailViewModel.refreshDetailInfo(detailViewModel.result.value!!.id)
+            Log.d("OpeningClubApplication", "observe")
             when (status) {
                 Event.Success -> {
                     BaseModal("성공", "동아리 신청을 오픈했습니다.", requireContext()).show()
@@ -458,6 +469,7 @@ class DetailFragment : BaseFragment<FragmentDetailBinding>(R.layout.fragment_det
                 Event.NotFound -> {
                     BaseModal("오류", "동아리를 찾을 수 없습니다.", requireContext()).show()
                 }
+                null -> {}
                 else -> {
                     BaseModal("오류", "알수 없는 오류 발생, 개발자에게 문의해주세요.", requireContext()).show()
                 }
@@ -468,6 +480,7 @@ class DetailFragment : BaseFragment<FragmentDetailBinding>(R.layout.fragment_det
     private fun observeCloseClubApplyEvent() {
         clubViewModel.closingClubApplication.observe(this) { status ->
             detailViewModel.refreshDetailInfo(detailViewModel.result.value!!.id)
+            Log.d("closingClubApplication", "observe")
             when (status) {
                 Event.Success -> {
                     BaseModal("성공", "동아리 신청을 마감했습니다.", requireContext()).show()
@@ -481,6 +494,7 @@ class DetailFragment : BaseFragment<FragmentDetailBinding>(R.layout.fragment_det
                 Event.NotFound -> {
                     BaseModal("오류", "동아리를 찾을 수 없습니다.", requireContext()).show()
                 }
+                null -> {}
                 else -> {
                     BaseModal("오류", "알수 없는 오류 발생, 개발자에게 문의해주세요.", requireContext()).show()
                 }

--- a/app/src/main/java/com/msg/gcms/presentation/view/club/detail/DetailFragment.kt
+++ b/app/src/main/java/com/msg/gcms/presentation/view/club/detail/DetailFragment.kt
@@ -79,6 +79,7 @@ class DetailFragment : BaseFragment<FragmentDetailBinding>(R.layout.fragment_det
     override fun onStop() {
         super.onStop()
         detailViewModel.clear()
+        clubViewModel.clear()
     }
 
     override fun init() {
@@ -90,6 +91,7 @@ class DetailFragment : BaseFragment<FragmentDetailBinding>(R.layout.fragment_det
 
     private fun observeEvent() {
         observeResult()
+        observeStatus()
     }
 
     private fun clickEvent() {
@@ -215,8 +217,6 @@ class DetailFragment : BaseFragment<FragmentDetailBinding>(R.layout.fragment_det
     private fun clickSubmitBtn() {
         binding.submitBtn.setOnClickListener {
             changeDialog()
-            clubViewModel.clear()
-            observeStatus()
         }
     }
 

--- a/app/src/main/java/com/msg/gcms/presentation/viewmodel/ClubDetailViewModel.kt
+++ b/app/src/main/java/com/msg/gcms/presentation/viewmodel/ClubDetailViewModel.kt
@@ -22,8 +22,8 @@ class ClubDetailViewModel @Inject constructor(
 
     private val TAG = "GetDetailViewModel"
 
-    private var _result = MutableLiveData<ClubDetailData?>()
-    val result: LiveData<ClubDetailData?> get() = _result
+    private var _result = MutableLiveData<ClubDetailData>()
+    val result: LiveData<ClubDetailData> get() = _result
 
     private val _showNav = MutableLiveData<Boolean>()
     val showNav: LiveData<Boolean> get() = _showNav
@@ -31,8 +31,8 @@ class ClubDetailViewModel @Inject constructor(
     private val _isProfile = MutableLiveData<Boolean>()
     val isProfile: LiveData<Boolean> get() = _isProfile
 
-    private var _getClubDetail = MutableLiveData<Event?>()
-    val getClubDetail: LiveData<Event?> get() = _getClubDetail
+    private var _getClubDetail = MutableLiveData<Event>()
+    val getClubDetail: LiveData<Event> get() = _getClubDetail
 
     private val _refreshClubDetail = MutableLiveData<Event>()
     val refreshClubDetail: LiveData<Event> get() = _refreshClubDetail

--- a/app/src/main/java/com/msg/gcms/presentation/viewmodel/ClubDetailViewModel.kt
+++ b/app/src/main/java/com/msg/gcms/presentation/viewmodel/ClubDetailViewModel.kt
@@ -97,13 +97,6 @@ class ClubDetailViewModel @Inject constructor(
         }
     }
 
-    // Todo (KimHs) 이름 좀 명시적으로 바꿔주세요
-    fun setResult(myClubResult: ClubDetailData) {
-        if (_result.value == null) {
-            _result.value = myClubResult
-        }
-    }
-
     fun setNav(boolean: Boolean) {
         _showNav.value = boolean
     }

--- a/app/src/main/java/com/msg/gcms/presentation/viewmodel/ClubDetailViewModel.kt
+++ b/app/src/main/java/com/msg/gcms/presentation/viewmodel/ClubDetailViewModel.kt
@@ -31,8 +31,8 @@ class ClubDetailViewModel @Inject constructor(
     private val _isProfile = MutableLiveData<Boolean>()
     val isProfile: LiveData<Boolean> get() = _isProfile
 
-    private val _getClubDetail = MutableLiveData<Event>()
-    val getClubDetail: LiveData<Event> get() = _getClubDetail
+    private val _getClubDetail = MutableLiveData<Event?>()
+    val getClubDetail: LiveData<Event?> get() = _getClubDetail
 
     private val _refreshClubDetail = MutableLiveData<Event>()
     val refreshClubDetail: LiveData<Event> get() = _refreshClubDetail
@@ -112,7 +112,8 @@ class ClubDetailViewModel @Inject constructor(
         _isProfile.value = boolean
     }
 
-    fun clearResult() {
+    fun clear() {
         _result.value = null
+        _getClubDetail.value = null
     }
 }

--- a/app/src/main/java/com/msg/gcms/presentation/viewmodel/ClubDetailViewModel.kt
+++ b/app/src/main/java/com/msg/gcms/presentation/viewmodel/ClubDetailViewModel.kt
@@ -22,7 +22,7 @@ class ClubDetailViewModel @Inject constructor(
 
     private val TAG = "GetDetailViewModel"
 
-    private val _result = MutableLiveData<ClubDetailData?>()
+    private var _result = MutableLiveData<ClubDetailData?>()
     val result: LiveData<ClubDetailData?> get() = _result
 
     private val _showNav = MutableLiveData<Boolean>()
@@ -31,7 +31,7 @@ class ClubDetailViewModel @Inject constructor(
     private val _isProfile = MutableLiveData<Boolean>()
     val isProfile: LiveData<Boolean> get() = _isProfile
 
-    private val _getClubDetail = MutableLiveData<Event?>()
+    private var _getClubDetail = MutableLiveData<Event?>()
     val getClubDetail: LiveData<Event?> get() = _getClubDetail
 
     private val _refreshClubDetail = MutableLiveData<Event>()
@@ -112,8 +112,8 @@ class ClubDetailViewModel @Inject constructor(
         _isProfile.value = boolean
     }
 
-    fun clear() {
-        _result.value = null
-        _getClubDetail.value = null
+    fun initializationProperties() {
+        _result = MutableLiveData()
+        _getClubDetail = MutableLiveData()
     }
 }

--- a/app/src/main/java/com/msg/gcms/presentation/viewmodel/ClubViewModel.kt
+++ b/app/src/main/java/com/msg/gcms/presentation/viewmodel/ClubViewModel.kt
@@ -38,16 +38,16 @@ class ClubViewModel @Inject constructor(
     // private val _getClubStatus = MutableLiveData<Event>()
     // val getClubStatus: LiveData<Event> get() = _getClubStatus
 
-    private val _cancelClubApply = MutableLiveData<Event?>()
+    private var _cancelClubApply = MutableLiveData<Event?>()
     val cancelClubApply: LiveData<Event?> get() = _cancelClubApply
 
-    private val _applyClub = MutableLiveData<Event?>()
+    private var _applyClub = MutableLiveData<Event?>()
     val applyClub: LiveData<Event?> get() = _applyClub
 
-    private val _closingClubApplication = MutableLiveData<Event?>()
+    private var _closingClubApplication = MutableLiveData<Event?>()
     val closingClubApplication: LiveData<Event?> get() = _closingClubApplication
 
-    private val _openingClubApplication = MutableLiveData<Event?>()
+    private var _openingClubApplication = MutableLiveData<Event?>()
     val openingClubApplication: LiveData<Event?> get() = _openingClubApplication
 
     private val _deleteClub = MutableLiveData<Event>()
@@ -185,10 +185,10 @@ class ClubViewModel @Inject constructor(
         }
     }
 
-    fun clear() {
-        _applyClub.value = null
-        _cancelClubApply.value = null
-        _openingClubApplication.value = null
-        _closingClubApplication.value = null
+    fun initializationProperties() {
+        _applyClub = MutableLiveData()
+        _cancelClubApply = MutableLiveData()
+        _openingClubApplication = MutableLiveData()
+        _closingClubApplication = MutableLiveData()
     }
 }

--- a/app/src/main/java/com/msg/gcms/presentation/viewmodel/ClubViewModel.kt
+++ b/app/src/main/java/com/msg/gcms/presentation/viewmodel/ClubViewModel.kt
@@ -38,17 +38,17 @@ class ClubViewModel @Inject constructor(
     // private val _getClubStatus = MutableLiveData<Event>()
     // val getClubStatus: LiveData<Event> get() = _getClubStatus
 
-    private var _cancelClubApply = MutableLiveData<Event?>()
-    val cancelClubApply: LiveData<Event?> get() = _cancelClubApply
+    private var _cancelClubApply = MutableLiveData<Event>()
+    val cancelClubApply: LiveData<Event> get() = _cancelClubApply
 
-    private var _applyClub = MutableLiveData<Event?>()
-    val applyClub: LiveData<Event?> get() = _applyClub
+    private var _applyClub = MutableLiveData<Event>()
+    val applyClub: LiveData<Event> get() = _applyClub
 
-    private var _closingClubApplication = MutableLiveData<Event?>()
-    val closingClubApplication: LiveData<Event?> get() = _closingClubApplication
+    private var _closingClubApplication = MutableLiveData<Event>()
+    val closingClubApplication: LiveData<Event> get() = _closingClubApplication
 
-    private var _openingClubApplication = MutableLiveData<Event?>()
-    val openingClubApplication: LiveData<Event?> get() = _openingClubApplication
+    private var _openingClubApplication = MutableLiveData<Event>()
+    val openingClubApplication: LiveData<Event> get() = _openingClubApplication
 
     private val _deleteClub = MutableLiveData<Event>()
     val deleteClub: LiveData<Event> get() = _deleteClub

--- a/app/src/main/java/com/msg/gcms/presentation/viewmodel/ClubViewModel.kt
+++ b/app/src/main/java/com/msg/gcms/presentation/viewmodel/ClubViewModel.kt
@@ -38,17 +38,17 @@ class ClubViewModel @Inject constructor(
     // private val _getClubStatus = MutableLiveData<Event>()
     // val getClubStatus: LiveData<Event> get() = _getClubStatus
 
-    private val _cancelClubApply = MutableLiveData<Event>()
-    val cancelClubApply: LiveData<Event> get() = _cancelClubApply
+    private val _cancelClubApply = MutableLiveData<Event?>()
+    val cancelClubApply: LiveData<Event?> get() = _cancelClubApply
 
-    private val _applyClub = MutableLiveData<Event>()
-    val applyClub: LiveData<Event> get() = _applyClub
+    private val _applyClub = MutableLiveData<Event?>()
+    val applyClub: LiveData<Event?> get() = _applyClub
 
-    private val _closingClubApplication = MutableLiveData<Event>()
-    val closingClubApplication: LiveData<Event> get() = _closingClubApplication
+    private val _closingClubApplication = MutableLiveData<Event?>()
+    val closingClubApplication: LiveData<Event?> get() = _closingClubApplication
 
-    private val _openingClubApplication = MutableLiveData<Event>()
-    val openingClubApplication: LiveData<Event> get() = _openingClubApplication
+    private val _openingClubApplication = MutableLiveData<Event?>()
+    val openingClubApplication: LiveData<Event?> get() = _openingClubApplication
 
     private val _deleteClub = MutableLiveData<Event>()
     val deleteClub: LiveData<Event> get() = _deleteClub
@@ -183,5 +183,12 @@ class ClubViewModel @Inject constructor(
                 }
             }
         }
+    }
+
+    fun clear() {
+        _applyClub.value = null
+        _cancelClubApply.value = null
+        _openingClubApplication.value = null
+        _closingClubApplication.value = null
     }
 }


### PR DESCRIPTION
## PR 정보
- 디테일 페이지가 onStop될 때마다 값을 초기화 해줌으로써 다이얼로그가 비정상적인 상황에 띄워지지 않도록 함

## 주요코드
- 초기화 코드
https://github.com/GSM-MSG/GCMS-Android/blob/07d4a1f14f56c23e176f5234df1406a3ff62e006/app/src/main/java/com/msg/gcms/presentation/viewmodel/ClubDetailViewModel.kt#L115-L118
https://github.com/GSM-MSG/GCMS-Android/blob/07d4a1f14f56c23e176f5234df1406a3ff62e006/app/src/main/java/com/msg/gcms/presentation/viewmodel/ClubViewModel.kt#L188-L194
- onStop
https://github.com/GSM-MSG/GCMS-Android/blob/07d4a1f14f56c23e176f5234df1406a3ff62e006/app/src/main/java/com/msg/gcms/presentation/view/club/detail/DetailFragment.kt#L79-L83