### PR TITLE
🔀 ::(#325) 무한 백 버튼 및 버그 해결

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,11 +17,6 @@
         android:theme="@style/Theme.MSGGCMS"
         android:usesCleartextTraffic="true">
         <activity
-            android:name=".presentation.view.clubmaker.MakeClubActivity"
-            android:exported="true"
-            android:windowSoftInputMode="adjustNothing" >
-        </activity>
-        <activity
             android:name=".presentation.view.splash.SplashActivity"
             android:exported="true">
             <intent-filter>
@@ -31,22 +26,29 @@
             </intent-filter>
         </activity>
         <activity
+            android:name=".presentation.view.clubmaker.MakeClubActivity"
+            android:exported="true"
+            android:windowSoftInputMode="adjustNothing" />
+        <activity
             android:windowSoftInputMode="adjustResize"
             android:name=".presentation.view.intro.IntroActivity"
-            android:exported="true">
-        </activity>
+            android:exported="true" />
         <activity
             android:name=".presentation.view.main.MainActivity"
-            android:exported="true" >
-        </activity>
-        <activity android:name=".presentation.view.profile.ProfileActivity" />
+            android:exported="true" />
+        <activity
+            android:name=".presentation.view.profile.ProfileActivity"
+            android:exported="false" />
         <activity
             android:name=".presentation.view.withdrawal.WithdrawalActivity"
             android:exported="false" />
-        <activity android:name=".presentation.view.editclub.EditClubActivity"
-            android:exported="false"/>
-        <activity android:name=".presentation.view.member_manage.MemberManageActivity"
-            android:exported="false"/>
+        <activity
+            android:name=".presentation.view.editclub.EditClubActivity"
+            android:exported="false"
+            android:windowSoftInputMode="adjustNothing" />
+        <activity
+            android:name=".presentation.view.member_manage.MemberManageActivity"
+            android:exported="false" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/msg/gcms/presentation/view/club/detail/DetailFragment.kt
+++ b/app/src/main/java/com/msg/gcms/presentation/view/club/detail/DetailFragment.kt
@@ -68,7 +68,7 @@ class DetailFragment : BaseFragment<FragmentDetailBinding>(R.layout.fragment_det
         super.onAttach(context)
         callback = object : OnBackPressedCallback(true) {
             override fun handleOnBackPressed() {
-                exitActivity(requireActivity())
+                goBack()
             }
         }
         requireActivity().onBackPressedDispatcher.addCallback(this, callback)

--- a/app/src/main/java/com/msg/gcms/presentation/view/clubmaker/search_student/StudentSearchFragment.kt
+++ b/app/src/main/java/com/msg/gcms/presentation/view/clubmaker/search_student/StudentSearchFragment.kt
@@ -47,7 +47,6 @@ class StudentSearchFragment :
     override fun init() {
         binding.fragment = this
         observeEvent()
-        activity?.window?.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_NOTHING)
         settingRecyclerView()
     }
 

--- a/app/src/main/java/com/msg/gcms/presentation/view/editclub/EditSearchFragment.kt
+++ b/app/src/main/java/com/msg/gcms/presentation/view/editclub/EditSearchFragment.kt
@@ -54,7 +54,6 @@ class EditSearchFragment : BaseFragment<FragmentEditSearchBinding>(R.layout.frag
     override fun init() {
         binding.fragment = this
         observeEvent()
-        activity?.window?.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_NOTHING)
         settingRecyclerView()
         memberList = editViewModel.addedMemberData.value!!.toMutableList()
     }

--- a/app/src/main/java/com/msg/gcms/presentation/view/main/MainActivity.kt
+++ b/app/src/main/java/com/msg/gcms/presentation/view/main/MainActivity.kt
@@ -68,9 +68,10 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main) {
     }
 
     override fun onBackPressed() {
-        supportFragmentManager.fragments.filter { it is OnBackPressedListener }
-            .map { it as OnBackPressedListener }
-            .forEach { it.onBackPressed(); return }
+        if (onBackPressedDispatcher.hasEnabledCallbacks()) {
+            onBackPressedDispatcher.onBackPressed()
+            return
+        }
 
         if (System.currentTimeMillis() - backButtonWait >= 2000) {
             backButtonWait = System.currentTimeMillis()

--- a/app/src/main/java/com/msg/gcms/presentation/view/member_manage/MemberManageActivity.kt
+++ b/app/src/main/java/com/msg/gcms/presentation/view/member_manage/MemberManageActivity.kt
@@ -128,13 +128,17 @@ class MemberManageActivity :
     }
 
     private fun clickExpandable() = with(binding) {
-        memberListBtn.setOnClickListener {
-            if (memberList.visibility == View.GONE) viewModel.getMember()
-            expandableAnim(memberListBtn, memberList.visibility, memberList)
+        listOf(memberListBtn, memberListLayout).forEach {
+            it.setOnClickListener {
+                if (memberList.visibility == View.GONE) viewModel.getMember()
+                expandableAnim(memberListBtn, memberList.visibility, memberList)
+            }
         }
-        applicantListBtn.setOnClickListener {
-            if (memberList.visibility == View.GONE) viewModel.getApplicant()
-            expandableAnim(applicantListBtn, applicantList.visibility, applicantList)
+        listOf(applicantListBtn, applicantListLayout).forEach {
+            it.setOnClickListener {
+                if (memberList.visibility == View.GONE) viewModel.getApplicant()
+                expandableAnim(applicantListBtn, applicantList.visibility, applicantList)
+            }
         }
     }
 

--- a/app/src/main/res/layout/activity_member_management.xml
+++ b/app/src/main/res/layout/activity_member_management.xml
@@ -42,6 +42,7 @@
         </LinearLayout>
 
         <LinearLayout
+            android:id="@+id/memberListLayout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="horizontal"
@@ -79,6 +80,7 @@
             android:layout_height="wrap_content"/>
 
         <LinearLayout
+            android:id="@+id/applicantListLayout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="horizontal"


### PR DESCRIPTION
## PR 정보
- 프로필 페이지에서 클럽 페이지로 이동할 때 무한 백 버튼 문제 해결
- 클럽 수정 시 구성원 추가할때 리사이즈 없애기
- 멤버 관리 시 클릭 범위 늘리기

## 작업 결과
- 프래그먼트에서 백버튼 리스너가 있는 지 확인 후 있다면, 백버튼 리스너 실행 후 return
- https://github.com/GSM-MSG/GCMS-Android/blob/ddd9fecbbb9d8cdb9885aecb43e63a9dce46d133/app/src/main/java/com/msg/gcms/presentation/view/main/MainActivity.kt#L71-L74
- editClubActivity에 windowSoftInputMode추가
- https://github.com/GSM-MSG/GCMS-Android/blob/ddd9fecbbb9d8cdb9885aecb43e63a9dce46d133/app/src/main/AndroidManifest.xml#L45-L48