### PR TITLE
🔀 :: (#341) 이미지 업로드 시 문제 해결

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,8 +15,8 @@ android {
         applicationId = "com.msg.gcms"
         minSdk = Versions.MIN_SDK_VERSION
         targetSdk = Versions.TARGET_SDK_VERSION
-        versionCode = 4
-        versionName = "2.0.2"
+        versionCode = 5
+        versionName = "2.0.3"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
         buildConfigField(

--- a/app/src/main/java/com/msg/gcms/presentation/utils/FileUtil.kt
+++ b/app/src/main/java/com/msg/gcms/presentation/utils/FileUtil.kt
@@ -13,6 +13,7 @@ import okhttp3.MultipartBody
 import okhttp3.RequestBody.Companion.asRequestBody
 import java.io.File
 import java.io.FileOutputStream
+import java.net.URLDecoder
 
 @SuppressLint("Range")
 fun Uri.toFile(context: Context): File {
@@ -45,7 +46,7 @@ fun File.toMultiPartBody(): MultipartBody.Part =
     )
 
 private fun Uri.getFileName(context: Context): String {
-    val name = this.toString().split("/").last()
+    val name = URLDecoder.decode(toString().split("/").last(), Charsets.UTF_8.name())
     val ext = context.contentResolver.getType(this)!!.split("/").last()
     return "$name.$ext"
 }


### PR DESCRIPTION
## PR 정보
- 이미지 업로드 할 때 파일이 s3에서 못 들어가지는 오류 해결

## 작업 결과
- 이미지 url을 얻을 때 UTF-8로 인코딩 됐던 것을 디코딩 시켜서 해결
- https://github.com/GSM-MSG/GCMS-Android/blob/ae3436ce2f51566e68f1aa3cb8ca61214e6eafff/app/src/main/java/com/msg/gcms/presentation/utils/FileUtil.kt#L49-L51