### PR TITLE
🔀 :: (#346) 디테일 페이지에서 클럽아이디 사라지는 버그 해결

### DIFF
--- a/app/src/main/java/com/msg/gcms/data/remote/dto/club/get_club_detail/ClubMemberResponse.kt
+++ b/app/src/main/java/com/msg/gcms/data/remote/dto/club/get_club_detail/ClubMemberResponse.kt
@@ -16,6 +16,6 @@ data class ClubMemberResponse(
     val `class`: Int,
     @SerializedName("num")
     val num: Int,
-    @SerializedName("userImg")
+    @SerializedName("profileImg")
     val userImg: String?,
 )

--- a/app/src/main/java/com/msg/gcms/presentation/view/club/ClubFragment.kt
+++ b/app/src/main/java/com/msg/gcms/presentation/view/club/ClubFragment.kt
@@ -53,8 +53,10 @@ class ClubFragment : BaseFragment<FragmentClubBinding>(R.layout.fragment_club) {
 
     private fun clubTxt() {
         mainViewModel.clubName.observe(this) {
+            if (binding.clubNameTxt.text != mainViewModel.clubName.value) {
+                mainViewModel.getClubList()
+            }
             binding.clubNameTxt.text = mainViewModel.clubName.value
-            mainViewModel.getClubList()
         }
     }
 

--- a/app/src/main/java/com/msg/gcms/presentation/view/club/detail/DetailFragment.kt
+++ b/app/src/main/java/com/msg/gcms/presentation/view/club/detail/DetailFragment.kt
@@ -252,8 +252,7 @@ class DetailFragment : BaseFragment<FragmentDetailBinding>(R.layout.fragment_det
                                         clubId = detailViewModel.result.value!!.id
                                     )
                                     dialog.dismiss()
-                                    // requireActivity().supportFragmentManager.beginTransaction()
-                                    //     .replace(R.id.fragment_club, DetailFragment()).commit()
+                                    goBack()
                                 }
                             }
                         }
@@ -279,8 +278,7 @@ class DetailFragment : BaseFragment<FragmentDetailBinding>(R.layout.fragment_det
                                         detailViewModel.result.value!!.id
                                     )
                                     dialog.dismiss()
-                                    requireActivity().supportFragmentManager.beginTransaction()
-                                        .replace(R.id.fragment_club, ClubFragment()).commit()
+                                    goBack()
                                     detailViewModel.setNav(true)
                                 }
                             }

--- a/app/src/main/java/com/msg/gcms/presentation/view/club/detail/DetailFragment.kt
+++ b/app/src/main/java/com/msg/gcms/presentation/view/club/detail/DetailFragment.kt
@@ -84,7 +84,7 @@ class DetailFragment : BaseFragment<FragmentDetailBinding>(R.layout.fragment_det
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
         if (requestCode == 0) {
-            detailViewModel.refreshDetailInfo(resultCode.toLong())
+            detailViewModel.refreshDetailInfo(requireActivity().intent.getLongExtra("clubId", 0L))
         }
     }
 

--- a/app/src/main/java/com/msg/gcms/presentation/view/club/detail/DetailFragment.kt
+++ b/app/src/main/java/com/msg/gcms/presentation/view/club/detail/DetailFragment.kt
@@ -77,12 +77,15 @@ class DetailFragment : BaseFragment<FragmentDetailBinding>(R.layout.fragment_det
     override fun onDetach() {
         super.onDetach()
         callback.remove()
-    }
-
-    override fun onStop() {
-        super.onStop()
         detailViewModel.initializationProperties()
         clubViewModel.initializationProperties()
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+        if (requestCode == 0) {
+            detailViewModel.refreshDetailInfo(resultCode.toLong())
+        }
     }
 
     override fun init() {
@@ -266,7 +269,7 @@ class DetailFragment : BaseFragment<FragmentDetailBinding>(R.layout.fragment_det
                                 "clubId",
                                 detailViewModel.result.value!!.id
                             )
-                            startActivity(intent)
+                            startActivityForResult(intent, 0)
                         }
                         2 -> {
                             BaseDialog("동아리 삭제", "정말 삭제할꺼에요??", context!!).let { dialog ->
@@ -293,7 +296,7 @@ class DetailFragment : BaseFragment<FragmentDetailBinding>(R.layout.fragment_det
         val intent = Intent(context, MemberManageActivity::class.java)
         intent.putExtra("clubId", detailViewModel.result.value!!.id)
         intent.putExtra("role", detailViewModel.result.value!!.scope)
-        startActivity(intent)
+        startActivityForResult(intent, 0)
     }
 
     private fun checkRole() {
@@ -549,7 +552,11 @@ class DetailFragment : BaseFragment<FragmentDetailBinding>(R.layout.fragment_det
                     BaseModal("오류", "동아리를 찾을 수 없습니다.", requireContext()).show()
                 }
                 Event.Server -> {
-                    BaseModal("오류", "서버에 일시적인 오류가 발생하였습니다. \n 잠시후에 다시 시도해주세요", requireContext()).show()
+                    BaseModal(
+                        "오류",
+                        "서버에 일시적인 오류가 발생하였습니다. \n 잠시후에 다시 시도해주세요",
+                        requireContext()
+                    ).show()
                 }
                 else -> {
                     BaseModal("성공", "동아리를 탈퇴하였습니다.", requireContext()).show()

--- a/app/src/main/java/com/msg/gcms/presentation/view/editclub/EditClubFragment.kt
+++ b/app/src/main/java/com/msg/gcms/presentation/view/editclub/EditClubFragment.kt
@@ -467,6 +467,7 @@ class EditClubFragment : BaseFragment<FragmentEditClubBinding>(R.layout.fragment
             when (it) {
                 Event.Success -> {
                     shortToast("동아리 정보가 수정되었습니다.")
+                    requireActivity().setResult(editViewModel.clubInfo.value!!.id.toInt())
                     requireActivity().finish()
                 }
                 // Event.BadRequest -> {

--- a/app/src/main/java/com/msg/gcms/presentation/view/editclub/EditClubFragment.kt
+++ b/app/src/main/java/com/msg/gcms/presentation/view/editclub/EditClubFragment.kt
@@ -284,7 +284,10 @@ class EditClubFragment : BaseFragment<FragmentEditClubBinding>(R.layout.fragment
     }
 
     private fun clickBackBtn() {
-        requireActivity().setResult(editViewModel.clubInfo.value!!.id.toInt())
+        requireActivity().setResult(
+            Activity.RESULT_OK,
+            Intent().putExtra("clubId", editViewModel.clubInfo.value!!.id)
+        )
         requireActivity().finish()
     }
 
@@ -467,7 +470,10 @@ class EditClubFragment : BaseFragment<FragmentEditClubBinding>(R.layout.fragment
             when (it) {
                 Event.Success -> {
                     shortToast("동아리 정보가 수정되었습니다.")
-                    requireActivity().setResult(editViewModel.clubInfo.value!!.id.toInt())
+                    requireActivity().setResult(
+                        Activity.RESULT_OK,
+                        Intent().putExtra("clubId", editViewModel.clubInfo.value!!.id)
+                    )
                     requireActivity().finish()
                 }
                 // Event.BadRequest -> {

--- a/app/src/main/java/com/msg/gcms/presentation/view/editclub/EditClubFragment.kt
+++ b/app/src/main/java/com/msg/gcms/presentation/view/editclub/EditClubFragment.kt
@@ -284,6 +284,7 @@ class EditClubFragment : BaseFragment<FragmentEditClubBinding>(R.layout.fragment
     }
 
     private fun clickBackBtn() {
+        requireActivity().setResult(editViewModel.clubInfo.value!!.id.toInt())
         requireActivity().finish()
     }
 

--- a/app/src/main/java/com/msg/gcms/presentation/view/main/MainActivity.kt
+++ b/app/src/main/java/com/msg/gcms/presentation/view/main/MainActivity.kt
@@ -30,7 +30,7 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main) {
 
     override fun onResume() {
         super.onResume()
-        if (intent.getBooleanExtra("isProfile", false)) {
+        if (intent.getBooleanExtra("isProfile", false) && detailViewModel.isProfile.value == false) {
             detailViewModel.getDetail(intent.getLongExtra("clubId", 0))
             // detailViewModel.setResult(intent.getSerializableExtra("result") as ClubDetailData)
             detailViewModel.setIsProfile(true)

--- a/app/src/main/java/com/msg/gcms/presentation/view/member_manage/MemberManageActivity.kt
+++ b/app/src/main/java/com/msg/gcms/presentation/view/member_manage/MemberManageActivity.kt
@@ -155,6 +155,7 @@ class MemberManageActivity :
 
     private fun clickBackBtn() {
         binding.backBtn.setOnClickListener {
+            setResult(viewModel.clubId.value.toInt())
             finish()
         }
     }

--- a/app/src/main/java/com/msg/gcms/presentation/view/member_manage/MemberManageActivity.kt
+++ b/app/src/main/java/com/msg/gcms/presentation/view/member_manage/MemberManageActivity.kt
@@ -1,7 +1,9 @@
 package com.msg.gcms.presentation.view.member_manage
 
 import android.animation.ObjectAnimator
+import android.app.Activity
 import android.content.Context
+import android.content.Intent
 import android.view.View
 import androidx.activity.viewModels
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -156,7 +158,10 @@ class MemberManageActivity :
 
     private fun clickBackBtn() {
         binding.backBtn.setOnClickListener {
-            setResult(viewModel.clubId.value.toInt())
+            setResult(
+                Activity.RESULT_OK,
+                Intent().putExtra("clubId", viewModel.clubId.value)
+            )
             finish()
         }
     }

--- a/app/src/main/java/com/msg/gcms/presentation/view/member_manage/MemberManageActivity.kt
+++ b/app/src/main/java/com/msg/gcms/presentation/view/member_manage/MemberManageActivity.kt
@@ -47,13 +47,14 @@ class MemberManageActivity :
 
     override fun viewSetting() {
         viewModel.setClubId(intent.getLongExtra("clubId", 0))
+        viewModel.setRole(intent.getStringExtra("role") ?: "MEMBER")
         clickExpandable()
         clickBackBtn()
         viewTitle()
     }
 
     private fun viewTitle() {
-        if (intent.getStringExtra("role").equals("MEMBER")) binding.title.text = "동아리 멤버 확인하기"
+        if (viewModel.role.value == "MEMBER") binding.title.text = "동아리 멤버 확인하기"
     }
 
     private fun showDialog(title: String, msg: String, context: Context, action: () -> Unit) {
@@ -69,7 +70,7 @@ class MemberManageActivity :
     }
 
     private fun settingMemberAdapter() {
-        memberAdapter = MemberAdapter(viewModel.memberList.value!!, intent.getStringExtra("role")!!)
+        memberAdapter = MemberAdapter(viewModel.memberList.value!!, viewModel.role.value)
         memberAdapter.setItemOnClickListener(object : MemberAdapter.OnItemClickListener {
             override fun mandate(position: Int) {
                 showDialog(
@@ -99,7 +100,7 @@ class MemberManageActivity :
 
     private fun settingApplicantAdapter() {
         applicantAdapter =
-            ApplicantAdapter(viewModel.applicantList.value!!, intent.getStringExtra("role")!!)
+            ApplicantAdapter(viewModel.applicantList.value!!, viewModel.role.value)
         applicantAdapter.setOnClickListener(object : ApplicantAdapter.onClickListener {
             override fun accept(position: Int) {
                 showDialog(
@@ -227,6 +228,7 @@ class MemberManageActivity :
 
     private fun observeKickUserStatus() {
         viewModel.kickUserState.observe(this) {
+            viewModel.getMember()
             when (it) {
                 Event.Success -> {
                     BaseModal("성공", "강퇴를 완료하였습니다.", this).show()
@@ -252,6 +254,8 @@ class MemberManageActivity :
 
     private fun observeDelegateStatus() {
         viewModel.delegateState.observe(this) {
+            viewModel.getMember()
+            viewTitle()
             when (it) {
                 Event.Success -> {
                     BaseModal("성공", "권한 위임을 완료했습니다.", this).show()
@@ -290,6 +294,8 @@ class MemberManageActivity :
 
     private fun observeAcceptApplicantStatus() {
         viewModel.acceptApplicantState.observe(this) {
+            viewModel.getMember()
+            viewModel.getApplicant()
             when (it) {
                 Event.Success -> {
                     BaseModal("완료", "동아리 신청을 승인했습니다.", this).show()
@@ -325,6 +331,7 @@ class MemberManageActivity :
 
     private fun observeRejectApplicantStatus() {
         viewModel.rejectApplicantState.observe(this) {
+            viewModel.getApplicant()
             when (it) {
                 Event.Success -> {
                     BaseModal("완료", "동아리 신청을 거절했습니다.", this).show()

--- a/app/src/main/java/com/msg/gcms/presentation/view/profile/ProfileActivity.kt
+++ b/app/src/main/java/com/msg/gcms/presentation/view/profile/ProfileActivity.kt
@@ -55,8 +55,12 @@ class ProfileActivity : BaseActivity<ActivityProfileBinding>(R.layout.activity_p
         clickLogout()
     }
 
-    private fun myProfile() {
+    override fun onResume() {
+        super.onResume()
         profileViewModel.getUserInfo()
+    }
+
+    private fun myProfile() {
         profileViewModel.profileData.observe(this) {
             binding.apply {
                 userNameTxt.text = it.name

--- a/app/src/main/java/com/msg/gcms/presentation/viewmodel/ClubDetailViewModel.kt
+++ b/app/src/main/java/com/msg/gcms/presentation/viewmodel/ClubDetailViewModel.kt
@@ -27,7 +27,7 @@ class ClubDetailViewModel @Inject constructor(
     private val _showNav = MutableLiveData<Boolean>()
     val showNav: LiveData<Boolean> get() = _showNav
 
-    private val _isProfile = MutableLiveData<Boolean>()
+    private val _isProfile = MutableLiveData<Boolean>(false)
     val isProfile: LiveData<Boolean> get() = _isProfile
 
     private var _getClubDetail = MutableLiveData<Event>()

--- a/app/src/main/java/com/msg/gcms/presentation/viewmodel/MemberManageViewModel.kt
+++ b/app/src/main/java/com/msg/gcms/presentation/viewmodel/MemberManageViewModel.kt
@@ -50,6 +50,8 @@ class MemberManageViewModel @Inject constructor(
 
     private val _clubId = mutableStateOf<Long>(0)
     val clubId get() = _clubId
+    private val _role = mutableStateOf<String>("MEMBER")
+    val role get() = _role
 
     private val _getMemberListState = MutableLiveData<Event>()
     val getMemberListState: LiveData<Event> get() = _getMemberListState
@@ -71,6 +73,10 @@ class MemberManageViewModel @Inject constructor(
 
     fun setClubId(clubId: Long) {
         _clubId.value = clubId
+    }
+
+    fun setRole(role: String) {
+        _role.value = role
     }
 
     fun getMember() {
@@ -133,6 +139,7 @@ class MemberManageViewModel @Inject constructor(
                 clubId = _clubId.value,
                 body = DelegationOfManagerData(id)
             ).onSuccess {
+                _role.value = "MEMBER"
                 _delegateState.value = Event.Success
             }.onFailure {
                 _delegateState.value =

--- a/app/src/main/java/com/msg/gcms/presentation/viewmodel/MemberManageViewModel.kt
+++ b/app/src/main/java/com/msg/gcms/presentation/viewmodel/MemberManageViewModel.kt
@@ -49,6 +49,7 @@ class MemberManageViewModel @Inject constructor(
     // private val _clubType = MutableLiveData<String>()
 
     private val _clubId = mutableStateOf<Long>(0)
+    val clubId get() = _clubId
 
     private val _getMemberListState = MutableLiveData<Event>()
     val getMemberListState: LiveData<Event> get() = _getMemberListState


### PR DESCRIPTION
## PR 정보
디테일 페이지에서 다른 액티비티로 넘어갈 때 뷰모델이 초기화 되어서 NPE가 뜨는 에러 해결

## 작업 결과
- 디테일 페이지에서 intent를 할 때 startActivityForResult를 이용하여 값을 되받아와서 사용하였다.