### PR TITLE
🔀 :: (#414) - splash에서 인터넷 연결을 검사하도록 로직 추가

### DIFF
--- a/app/src/main/java/com/msg/gcms/presentation/view/splash/SplashActivity.kt
+++ b/app/src/main/java/com/msg/gcms/presentation/view/splash/SplashActivity.kt
@@ -1,10 +1,16 @@
 package com.msg.gcms.presentation.view.splash
 
 import android.annotation.SuppressLint
+import android.content.Context
+import android.content.Intent
+import android.net.ConnectivityManager
+import android.net.NetworkInfo
 import android.os.Bundle
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import com.msg.gcms.R
+import com.msg.gcms.domain.exception.NoInternetException
+import com.msg.gcms.presentation.base.BaseModal
 import com.msg.gcms.presentation.utils.enterActivity
 import com.msg.gcms.presentation.view.intro.IntroActivity
 import com.msg.gcms.presentation.view.main.MainActivity
@@ -23,9 +29,19 @@ class SplashActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_splash)
-        splashViewModel.checkIsLogin(this)
         //versionChecker = VersionChecker(this, afterLogic = { afterLogic() })
         observeIsLogin()
+        try {
+            checkIsInterConnected()
+        } catch (e: NoInternetException) {
+            BaseModal("에러", "인터넷 연결을 확인해주세요.", this).let { dialog ->
+                dialog.show()
+                dialog.dialogBinding.ok.setOnClickListener {
+                    finish()
+                    startActivity(Intent(this@SplashActivity, SplashActivity::class.java))
+                }
+            }
+        }
     }
 
     private fun observeIsLogin() {
@@ -36,6 +52,14 @@ class SplashActivity : AppCompatActivity() {
             }
         }
     }
+
+    private fun checkIsInterConnected() {
+        val cm: ConnectivityManager =
+            this.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+        val networkInfo: NetworkInfo? = cm.activeNetworkInfo
+        if (networkInfo == null) throw NoInternetException() else splashViewModel.checkIsLogin(this)
+    }
+
     //
     // override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
     //     super.onActivityResult(requestCode, resultCode, data)

--- a/app/src/main/java/com/msg/gcms/presentation/view/splash/SplashActivity.kt
+++ b/app/src/main/java/com/msg/gcms/presentation/view/splash/SplashActivity.kt
@@ -29,8 +29,25 @@ class SplashActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_splash)
+        observeEvent()
+        internetConnectionChecker()
         //versionChecker = VersionChecker(this, afterLogic = { afterLogic() })
+    }
+
+    private fun observeEvent() {
         observeIsLogin()
+    }
+
+    private fun observeIsLogin() {
+        splashViewModel.isLogin.observe(this) {
+            when (it) {
+                Event.Success -> enterActivity(this@SplashActivity, MainActivity(), true)
+                else -> enterActivity(this@SplashActivity, IntroActivity(), true)
+            }
+        }
+    }
+
+    private fun internetConnectionChecker() {
         try {
             checkIsInterConnected()
         } catch (e: NoInternetException) {
@@ -44,19 +61,10 @@ class SplashActivity : AppCompatActivity() {
         }
     }
 
-    private fun observeIsLogin() {
-        splashViewModel.isLogin.observe(this) {
-            when (it) {
-                Event.Success -> enterActivity(this@SplashActivity, MainActivity(), true)
-                else -> enterActivity(this@SplashActivity, IntroActivity(), true)
-            }
-        }
-    }
-
     private fun checkIsInterConnected() {
-        val cm: ConnectivityManager =
+        val connectivityManager: ConnectivityManager =
             this.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
-        val networkInfo: NetworkInfo? = cm.activeNetworkInfo
+        val networkInfo: NetworkInfo? = connectivityManager.activeNetworkInfo
         if (networkInfo == null) throw NoInternetException() else splashViewModel.checkIsLogin(this)
     }
 


### PR DESCRIPTION
## PR 정보
- splash화면에서 인터넷 연결을 검사하도록 로직을 추가합니다.

## 주요코드
- 인터넷 연결 검사 로직
https://github.com/GSM-MSG/GCMS-Android/blob/37c2f249ced1a47676b779c3f1e8fe3afea0e3b2/app/src/main/java/com/msg/gcms/presentation/view/splash/SplashActivity.kt#L56-L61